### PR TITLE
fix: use SEMANTIC_RELEASE_TOKEN to bypass branch protection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Install UV
         uses: astral-sh/setup-uv@v4
@@ -66,7 +67,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9.15.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           root_options: -vv
 
       - name: Build client package


### PR DESCRIPTION
## Summary
Fixes the release workflow failure caused by branch protection rules blocking direct pushes to main.

## Problem
The automated release workflow was failing with:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

The semantic-release action needs to push version bump commits directly to main, but repository branch protection requires all changes go through PRs.

## Solution
Updated the release workflow to use `SEMANTIC_RELEASE_TOKEN` instead of `GITHUB_TOKEN`:
- Checkout action now uses the token to clone the repo
- python-semantic-release action uses the token for git operations

This allows semantic-release to bypass branch protection rules using a personal access token.

## Configuration Required
After merging this PR, you'll need to:
1. Create a Personal Access Token with `repo` permissions
2. Add it as a repository secret named `SEMANTIC_RELEASE_TOKEN`
3. The next push to main will trigger a successful release

## References
- Follows the same pattern as katana-openapi-client
- Related to merged PR #31 which should trigger a patch release

🤖 Generated with [Claude Code](https://claude.com/claude-code)