### PR TITLE
fix: handle response.elapsed RuntimeError in logging hook

### DIFF
--- a/stocktrim_public_api_client/stocktrim_client.py
+++ b/stocktrim_public_api_client/stocktrim_client.py
@@ -597,11 +597,17 @@ class StockTrimClient(AuthenticatedClient):
     async def _log_response_metrics(self, response: httpx.Response) -> None:
         """Log response metrics for observability."""
         request = response.request
-        elapsed_ms = response.elapsed.total_seconds() * 1000
-        self.logger.debug(
-            f"{request.method} {request.url} -> {response.status_code} "
-            f"({elapsed_ms:.0f}ms)"
-        )
+        try:
+            elapsed_ms = response.elapsed.total_seconds() * 1000
+            self.logger.debug(
+                f"{request.method} {request.url} -> {response.status_code} "
+                f"({elapsed_ms:.0f}ms)"
+            )
+        except RuntimeError:
+            # elapsed is only available after response is read/closed
+            self.logger.debug(
+                f"{request.method} {request.url} -> {response.status_code}"
+            )
 
     def __repr__(self) -> str:
         """String representation of the client."""

--- a/uv.lock
+++ b/uv.lock
@@ -2127,7 +2127,7 @@ requires-dist = [
 
 [[package]]
 name = "stocktrim-openapi-client"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary
Fixes RuntimeError in the response metrics logging hook that was breaking MCP server tool calls.

## Problem
The `_log_response_metrics` hook was accessing `response.elapsed` before the response body was read, causing:
```
RuntimeError: '.elapsed' may only be accessed after the response has been read or closed.
```

This broke MCP server tool calls like `list_purchase_orders`.

## Root Cause
The hook is called as an event hook after receiving the response but before the body is read. The `elapsed` property is only available after the response stream has been consumed or explicitly closed.

## Solution
- Wrapped `response.elapsed` access in try/except
- Fall back to logging without elapsed time if RuntimeError is raised
- Preserves observability while preventing tool call failures

## Testing
- All 48 tests pass
- MCP server tool calls will no longer fail with RuntimeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)