### PR TITLE
docs: clarify product search is exact match only, remove deprecated methods

### DIFF
--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/services/products.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/services/products.py
@@ -54,25 +54,29 @@ class ProductService(BaseService):
         logger.info(f"Found {len(products)} products")
         return products
 
-    async def search(self, prefix: str) -> list[ProductsResponseDto]:
-        """Search products by code prefix.
+    async def find_by_exact_code(self, code: str) -> list[ProductsResponseDto]:
+        """Find products by exact code match.
+
+        Note: The StockTrim Products API only supports exact code matching,
+        not prefix or partial matching. For keyword search functionality,
+        use the Order Plan API.
 
         Args:
-            prefix: Product code prefix to search for
+            code: Exact product code to search for
 
         Returns:
-            List of matching products
+            List of matching products (0 or 1 item for exact match)
 
         Raises:
-            ValueError: If prefix is empty
+            ValueError: If code is empty
             Exception: If API call fails
         """
-        self.validate_not_empty(prefix, "Search prefix")
-        logger.info(f"Searching products with prefix: {prefix}")
+        self.validate_not_empty(code, "Product code")
+        logger.info(f"Finding product with exact code: {code}")
 
-        products = await self._client.products.search(prefix)
+        products = await self._client.products.find_by_exact_code(code)
 
-        logger.info(f"Found {len(products)} products matching prefix: {prefix}")
+        logger.info(f"Found {len(products)} products matching code: {code}")
         return products
 
     async def create(

--- a/stocktrim_mcp_server/tests/test_services/test_products.py
+++ b/stocktrim_mcp_server/tests/test_services/test_products.py
@@ -110,51 +110,53 @@ async def test_get_by_code_empty_code(product_service):
 
 
 # ============================================================================
-# Tests for search
+# Tests for find_by_exact_code
 # ============================================================================
 
 
 @pytest.mark.asyncio
-async def test_search_success(product_service, mock_client, sample_products):
-    """Test successfully searching products by prefix."""
+async def test_find_by_exact_code_success(
+    product_service, mock_client, sample_products
+):
+    """Test successfully finding products by exact code."""
     # Setup
-    mock_client.products.search = AsyncMock(return_value=sample_products)
+    mock_client.products.find_by_exact_code = AsyncMock(return_value=sample_products)
 
     # Execute
-    result = await product_service.search("WIDGET")
+    result = await product_service.find_by_exact_code("WIDGET-001")
 
     # Verify
     assert len(result) == 3
     assert result[0].product_code_readable == "WIDGET-001"
     assert result[1].product_code_readable == "WIDGET-002"
     assert result[2].product_code_readable == "WIDGET-003"
-    mock_client.products.search.assert_called_once_with("WIDGET")
+    mock_client.products.find_by_exact_code.assert_called_once_with("WIDGET-001")
 
 
 @pytest.mark.asyncio
-async def test_search_no_results(product_service, mock_client):
-    """Test searching when no products match."""
+async def test_find_by_exact_code_no_results(product_service, mock_client):
+    """Test finding products when no products match."""
     # Setup
-    mock_client.products.search = AsyncMock(return_value=[])
+    mock_client.products.find_by_exact_code = AsyncMock(return_value=[])
 
     # Execute
-    result = await product_service.search("NONEXISTENT")
+    result = await product_service.find_by_exact_code("NONEXISTENT")
 
     # Verify
     assert len(result) == 0
     assert result == []
-    mock_client.products.search.assert_called_once_with("NONEXISTENT")
+    mock_client.products.find_by_exact_code.assert_called_once_with("NONEXISTENT")
 
 
 @pytest.mark.asyncio
-async def test_search_empty_prefix(product_service):
-    """Test that empty prefix raises ValueError."""
+async def test_find_by_exact_code_empty(product_service):
+    """Test that empty code raises ValueError."""
     # Execute & Verify
-    with pytest.raises(ValueError, match="Search prefix cannot be empty"):
-        await product_service.search("")
+    with pytest.raises(ValueError, match="Product code cannot be empty"):
+        await product_service.find_by_exact_code("")
 
-    with pytest.raises(ValueError, match="Search prefix cannot be empty"):
-        await product_service.search("  ")
+    with pytest.raises(ValueError, match="Product code cannot be empty"):
+        await product_service.find_by_exact_code("  ")
 
 
 # ============================================================================

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -50,7 +50,7 @@ class TestHelpersIntegration:
         assert hasattr(stocktrim_client.products, "get_all")
         assert hasattr(stocktrim_client.products, "create")
         assert hasattr(stocktrim_client.products, "find_by_code")
-        assert hasattr(stocktrim_client.products, "search")
+        assert hasattr(stocktrim_client.products, "find_by_exact_code")
         assert hasattr(stocktrim_client.products, "exists")
 
         # Customers

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ requires-dist = [
 
 [[package]]
 name = "stocktrim-openapi-client"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

This PR documents and clarifies that the StockTrim Products API only supports exact code matching (not prefix or partial search), and removes deprecated methods that had misleading names.

## Changes

### Documentation
- ✅ Add API feedback section documenting Products endpoint 404 behavior
- ✅ Document that `code` parameter only supports exact matching
- ✅ Explain why 404 for query filtering is non-standard REST

### API Client (`stocktrim_public_api_client`)
- ✅ Update `get_all()` docs to clarify exact match only
- ✅ Add `find_by_exact_code()` method with clear naming
- ✅ Remove deprecated `search()` method
- ✅ Update tests to check for `find_by_exact_code()` instead of `search()`

### MCP Server (`stocktrim_mcp_server`)
- ✅ Update `find_by_exact_code()` docs with API limitation note
- ✅ Remove deprecated `search()` method
- ✅ Rename tests: `test_search_*` → `test_find_by_exact_code_*`

## Testing

- ✅ All 73 public API client tests pass
- ✅ All 276 MCP server tests pass
- ✅ Test function names now match the actual method names
- ✅ Pre-commit hooks pass (ruff, mdformat, pytest)

## Breaking Changes

Since we're pre-1.0, deprecated methods were removed rather than kept for backward compatibility:

- `ProductService.search()` → use `find_by_exact_code()` instead
- `Products.search()` → use `find_by_exact_code()` instead

**Note**: For keyword search functionality across product names, codes, and categories, use the Order Plan API (implemented in PR #99).

## Key Findings

The StockTrim Products API has two non-standard behaviors:

1. **Returns 404 for "no results"** - When filtering by code returns no matches, the API returns 404 instead of 200 with an empty array
2. **Exact match only** - The `code` query parameter only supports exact matching, not prefix or partial matching

We've documented these in the API feedback doc and handled them appropriately in our helper methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)