### PR TITLE
ci(mcp): include MCP server tests in root quality gate

### DIFF
--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -36,7 +36,14 @@ You are a verification agent. Your job is to confirm that work is complete and r
 
 ## Step 1: Run Verification Command
 
-This project uses **`uv run poe check`** as the verification command (format-check + lint + test). The MCP server has a separate test suite that lives in `stocktrim_mcp_server/tests/` — `uv run poe check` does NOT run those, so you must run them separately if MCP server code changed.
+This project uses **`uv run poe check`** as the verification command. As of #145 it runs the full pipeline:
+
+- `format-check` (ruff format + mdformat)
+- `lint` (ruff + ty + yamllint)
+- `test` (root client library, 73 tests)
+- `test-mcp` (MCP server, 318 tests)
+
+One command, both suites. No need to `cd stocktrim_mcp_server` separately.
 
 Quick discovery (for safety):
 

--- a/.claude/skills/add-mcp-tool/SKILL.md
+++ b/.claude/skills/add-mcp-tool/SKILL.md
@@ -19,7 +19,7 @@ Surface an existing client helper as an MCP tool with proper Pydantic typing, se
 
 - **Tools call services; services call helpers; helpers call `generated/`** — never bypass a layer.
 - **Pydantic models for inputs/outputs** — FastMCP requires typed schemas; raw dicts are not acceptable.
-- **MCP tests live in `stocktrim_mcp_server/tests/`** and are NOT covered by `uv run poe check` (which only runs root `tests/`). You must run them separately.
+- **MCP tests live in `stocktrim_mcp_server/tests/`** and run via `uv run poe test-mcp`. They're also part of `uv run poe check` (since #145), so a successful `check` covers both suites in one go.
 - **Mock the StockTrim client at the service boundary** — don't hit real HTTP from MCP tests.
 
 ## ASSUMES
@@ -81,17 +81,20 @@ Use the existing test fixtures from `stocktrim_mcp_server/tests/conftest.py`. If
 
 ### 4. Run the tests
 
-```bash
-cd stocktrim_mcp_server && uv run pytest tests/test_tools/test_<domain>.py -x
-```
-
-Then run the root suite to make sure nothing client-side regressed:
+For a fast MCP-only loop while iterating:
 
 ```bash
-cd .. && uv run poe check
+uv run poe test-mcp                                   # all MCP tests
+cd stocktrim_mcp_server && uv run pytest tests/test_tools/test_<domain>.py -x  # one file
 ```
 
-ALL must pass on both. CLAUDE.md zero-tolerance applies — fix any pre-existing failures, don't ignore them.
+When you're ready to commit, the full gate covers both client and MCP suites in one shot:
+
+```bash
+uv run poe check
+```
+
+ALL must pass. CLAUDE.md zero-tolerance applies — fix any pre-existing failures, don't ignore them.
 
 ### 5. Commit
 

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -19,7 +19,7 @@ Confirm the work is actually done by CLAUDE.md's standard: all tests pass, all l
 
 - **Pre-existing issues are NOT excuses** — if `uv run poe check` fails because of a test that was already broken, fix it before declaring the task done. CLAUDE.md is explicit: "ALL tests must pass, regardless of when the issues were introduced."
 - **No `# noqa`, no `# type: ignore`, no skipped tests** — these are forbidden shortcuts. Refactor instead.
-- **MCP server tests are NOT covered by `uv run poe check`** — they live in `stocktrim_mcp_server/tests/`. Run them separately if MCP code changed.
+- **MCP server tests are now covered by `uv run poe check`** via the `test-mcp` step (added under #145). One command runs both suites; one CI matrix run gates both.
 - **Must be on a feature branch** with all changes committed before this skill returns success.
 
 ## STANDARD PATH
@@ -40,17 +40,9 @@ git branch --show-current
 uv run poe check
 ```
 
-This runs `format-check`, `lint` (ruff + ty + yaml), and `test` for the root package. ALL must pass. Any failure — even one labeled "pre-existing" — is a blocker.
+This runs `format-check`, `lint` (ruff + ty + yaml), `test` (client library, 73 tests), and `test-mcp` (MCP server, 318 tests). ALL must pass. Any failure — even one labeled "pre-existing" — is a blocker.
 
-### 3. Run MCP server tests if relevant
-
-If any file under `stocktrim_mcp_server/` changed (check `git log main..HEAD --name-only`):
-
-```bash
-cd stocktrim_mcp_server && uv run pytest -x
-```
-
-ALL must pass.
+The MCP server suite is now part of `check` (since `feat(mcp): include MCP server tests in root quality gate`). You no longer need a separate `cd stocktrim_mcp_server && pytest` step — but you can still run `uv run poe test-mcp` standalone if you want a fast MCP-only loop.
 
 ### 4. Forbidden-pattern scan
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run tests with coverage
         run: uv run poe test-coverage
 
+      - name: Run MCP server tests
+        run: uv run poe test-mcp
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-packages
 
       - name: Check code formatting
         run: uv run poe format-check
@@ -69,7 +69,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-packages
 
       - name: Validate OpenAPI specification
         run: uv run poe validate-openapi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --all-packages
 
       - name: Run full CI pipeline
         run: uv run poe ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,9 +107,12 @@ git branch                 # Verify you're on a feature branch
 ### Testing
 
 ```bash
-uv run poe test                  # Run tests with pytest
+uv run poe test                  # Run client library tests with pytest
+uv run poe test-mcp              # Run MCP server tests (stocktrim_mcp_server/tests/)
 uv run poe test-coverage         # Run tests with coverage reports (HTML, terminal, XML)
 ```
+
+`uv run poe check` runs both `test` and `test-mcp`, so the MCP server suite cannot regress silently when only the client lib is touched.
 
 ### Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,8 @@ addopts = [
   "--timeout=30",     # 30 second timeout for tests
 ]
 testpaths = ["tests"]
-# Note: MCP server tests are excluded - they should be run separately in the MCP server's own test suite
+# Note: MCP server tests live in stocktrim_mcp_server/tests/ and are run via
+# `uv run poe test-mcp` (also included in `uv run poe check`).
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
@@ -338,6 +339,7 @@ test-integration = "pytest -m integration"
 test-docs = { shell = "CI_DOCS_BUILD=true pytest -m docs -v --timeout=600" }  # 10 minute timeout for docs
 test-no-docs = "pytest -m 'not docs'"
 test-all = "pytest"  # Run everything including docs (if CI_DOCS_BUILD is set)
+test-mcp = { shell = "cd stocktrim_mcp_server && pytest --timeout=30" }  # MCP server suite (separate workspace)
 
 # -----------------------------------------------------------------------------
 # OpenAPI and Code Generation Tasks
@@ -365,9 +367,9 @@ pre-commit-update = "pre-commit autoupdate"
 # -----------------------------------------------------------------------------
 # Combined Workflow Tasks
 # -----------------------------------------------------------------------------
-check = ["format-check", "lint", "test"]
+check = ["format-check", "lint", "test", "test-mcp"]
 fix = ["format", "lint-ruff-fix"]
-ci = ["format-check", "lint", "test-coverage", "docs-build"]
+ci = ["format-check", "lint", "test-coverage", "test-mcp", "docs-build"]
 prepare = ["format", "lint", "test", "validate-openapi", "validate-openapi-redocly"]
 validate-all = ["validate-openapi", "validate-openapi-redocly"]
 


### PR DESCRIPTION
## Summary

Phase 1 of the v3 modernization (#154). Closes the CI gap exposed by #155: the MCP server's test suite was structurally isolated from \`uv run poe check\` and the GitHub CI matrix, so dependabot's #139 grouped bump showed all checks green while silently regressing the MCP server.

### Changes

- **\`pyproject.toml\`**: new \`test-mcp\` poe task (\`cd stocktrim_mcp_server && pytest --timeout=30\`); added to both \`check\` and \`ci\` aggregates so a single command covers both suites.
- **\`.github/workflows/ci.yml\`**: new \"Run MCP server tests\" step in the matrix, right after coverage. Each Python version (3.11/3.12/3.13) now runs both suites.
- **Documentation**: updated CLAUDE.md, \`/quality-gate\` skill, \`/add-mcp-tool\` skill, and the \`verifier\` agent to point at the unified flow.

## Why one PR per phase

The fix-and-merge in #155 had to land first — otherwise this PR would land a green-on-broken-MCP-suite-tests CI step. With v3 compat fixed in #155, the MCP suite is green, and adding it to CI now hardens the gate.

## Test plan

- [x] \`uv run poe check\` runs 391 tests (73 client + 318 MCP) and stays green
- [ ] CI matrix shows the new \"Run MCP server tests\" step pass on Python 3.11/3.12/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)