### PR TITLE
feat(mcp): adopt ResponseCachingMiddleware for read-heavy tools and resources

### DIFF
--- a/docs/mcp-server/observability.md
+++ b/docs/mcp-server/observability.md
@@ -20,6 +20,12 @@ in OpenTelemetry, structured logs, and HTTP-level tracing.
   client library) logs API parse errors to capture real-API-vs-spec
   divergences. This is library-author concern, not operator concern, and is
   separate from the observability story below.
+- **Response caching** via FastMCP's `ResponseCachingMiddleware` is wired in
+  `server.py` with an in-memory store. Read tools cache for 5 minutes; resources
+  cache for 60 seconds; mutating tools (every `create_*`/`delete_*`/`set_*`/
+  `configure_*`/etc. surface) are excluded so cached entries are never returned
+  for state changes. Operators can swap the in-memory backend for Redis/disk
+  by overriding the middleware (see Caching below).
 
 ## What the server does NOT ship
 
@@ -117,6 +123,49 @@ HTTPXClientInstrumentor().instrument()
 ```
 
 You'll get spans for every API call, attached to the parent tool span.
+
+## Caching
+
+The server ships with FastMCP's `ResponseCachingMiddleware` enabled by default,
+backed by an in-memory store:
+
+| Surface           | TTL     | Notes                                              |
+| ----------------- | ------- | -------------------------------------------------- |
+| `call_tool`       | 5 min   | Mutating tools (`create_*`, `delete_*`, etc.) excluded |
+| `read_resource`   | 60 sec  | Resources are for discovery — favor freshness      |
+| `list_tools/etc.` | 5 min   | FastMCP defaults                                   |
+
+**Staleness window**: a successful mutation invalidates downstream reads only
+when the next read miss exceeds the TTL. For most workflows the 5-minute window
+is acceptable — pair-programmer agents typically don't mutate and re-read the
+same entity within seconds. If your workload does, see "Tightening cache
+freshness" below.
+
+### Swapping the cache backend
+
+To use Redis (multi-process or persistent across restarts):
+
+```python
+from key_value.aio.stores.redis import RedisStore
+from fastmcp.server.middleware.caching import ResponseCachingMiddleware
+from stocktrim_mcp_server.server import mcp
+
+# Replace the default in-memory middleware before mcp.run()
+mcp.middleware = [m for m in mcp.middleware if not isinstance(m, ResponseCachingMiddleware)]
+mcp.add_middleware(ResponseCachingMiddleware(
+    cache_storage=RedisStore(host="redis.internal", port=6379),
+    # …existing call_tool_settings / read_resource_settings…
+))
+```
+
+### Tightening cache freshness
+
+Three options, ordered cheapest to most invasive:
+
+1. **Lower TTLs** — pass smaller `ttl` values via `CallToolSettings(ttl=60)` etc.
+2. **Add tools to `excluded_tools`** — any tool you list there is never cached.
+3. **Disable response caching entirely** — remove the middleware after
+   constructing `mcp` (see snippet above; just don't re-add it).
 
 ## Why this design
 

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/server.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/server.py
@@ -17,6 +17,11 @@ from typing import Any
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from fastmcp.server.middleware.caching import (
+    CallToolSettings,
+    ReadResourceSettings,
+    ResponseCachingMiddleware,
+)
 
 from stocktrim_mcp_server import __version__
 from stocktrim_mcp_server.context import ServerContext
@@ -371,6 +376,50 @@ register_all_tools(mcp)
 register_all_resources(mcp)
 register_all_prompts(mcp)
 logger.info("prompts_registered")
+
+
+# Tools that mutate StockTrim state. They never serve cached responses, and
+# their successful execution implicitly stales any cached read for the same
+# entity (TTL keeps the staleness window bounded — defaults to 5 minutes).
+_MUTATING_TOOLS = [
+    # Foundation create/delete/set
+    "create_product",
+    "delete_product",
+    "create_supplier",
+    "delete_supplier",
+    "create_purchase_order",
+    "delete_purchase_order",
+    "create_sales_order",
+    "delete_sales_orders",
+    "create_location",
+    "set_product_inventory",
+    # Workflow mutations
+    "configure_product",
+    "products_configure_lifecycle",
+    "manage_forecast_group",
+    "update_forecast_settings",
+    "forecasts_update_and_monitor",
+    "create_supplier_with_products",
+    "generate_purchase_orders_from_urgent_items",
+]
+
+
+# Response caching: in-memory by default. Operators can swap in Redis/disk via
+# their own middleware wiring; see docs/mcp-server/observability.md.
+mcp.add_middleware(
+    ResponseCachingMiddleware(
+        call_tool_settings=CallToolSettings(
+            ttl=300,  # 5 min — read-heavy tools (products, suppliers, locations)
+            enabled=True,
+            excluded_tools=_MUTATING_TOOLS,
+        ),
+        read_resource_settings=ReadResourceSettings(
+            ttl=60,  # 60s — resources are for discovery; favor freshness
+            enabled=True,
+        ),
+    )
+)
+logger.info("response_caching_enabled", excluded_tools=len(_MUTATING_TOOLS))
 
 
 def main(**kwargs: Any) -> None:

--- a/stocktrim_mcp_server/tests/test_caching.py
+++ b/stocktrim_mcp_server/tests/test_caching.py
@@ -1,0 +1,82 @@
+"""Tests for ResponseCachingMiddleware wiring on the StockTrim MCP server.
+
+Behavior of the caching middleware itself is fastmcp's responsibility; these
+tests verify our wiring choices: the middleware is registered, mutating tools
+are excluded, and TTLs are sane.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.server.middleware.caching import ResponseCachingMiddleware
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide fake creds so server.py can import without raising at lifespan time."""
+    monkeypatch.setenv("STOCKTRIM_API_AUTH_ID", "test-id")
+    monkeypatch.setenv("STOCKTRIM_API_AUTH_SIGNATURE", "test-sig")
+
+
+def _get_caching_middleware() -> ResponseCachingMiddleware:
+    """Import the configured server and return its caching middleware."""
+    # Import is inside the function so fixtures run first.
+    from stocktrim_mcp_server.server import mcp
+
+    matching = [m for m in mcp.middleware if isinstance(m, ResponseCachingMiddleware)]
+    assert matching, "ResponseCachingMiddleware not registered on mcp"
+    return matching[0]
+
+
+def test_response_caching_middleware_registered() -> None:
+    """ResponseCachingMiddleware is wired on the production server."""
+    assert _get_caching_middleware() is not None
+
+
+def test_mutating_tools_are_excluded_from_cache() -> None:
+    """Every create/delete/set/configure tool is in the cache exclusion list.
+
+    Caching a mutation would return a no-op success on subsequent calls within
+    the TTL — silent data loss. The exclusion list is the safety guard.
+    """
+    middleware = _get_caching_middleware()
+    excluded = set(middleware._call_tool_settings.get("excluded_tools", []))
+
+    # Every mutation surface the server exposes today.
+    expected = {
+        "create_product",
+        "delete_product",
+        "create_supplier",
+        "delete_supplier",
+        "create_purchase_order",
+        "delete_purchase_order",
+        "create_sales_order",
+        "delete_sales_orders",
+        "create_location",
+        "set_product_inventory",
+        "configure_product",
+        "products_configure_lifecycle",
+        "manage_forecast_group",
+        "update_forecast_settings",
+        "forecasts_update_and_monitor",
+        "create_supplier_with_products",
+        "generate_purchase_orders_from_urgent_items",
+    }
+    missing = expected - excluded
+    assert not missing, f"mutating tools missing from cache exclusion: {missing}"
+
+
+def test_call_tool_ttl_is_bounded() -> None:
+    """call_tool TTL stays under 10 minutes — bounds the staleness window."""
+    middleware = _get_caching_middleware()
+    ttl = middleware._call_tool_settings.get("ttl")
+    assert ttl is not None, "call_tool TTL should be set explicitly"
+    assert 0 < ttl <= 600, f"call_tool TTL out of bounds: {ttl}"
+
+
+def test_read_resource_ttl_favors_freshness() -> None:
+    """read_resource TTL is short — resources are for discovery, freshness wins."""
+    middleware = _get_caching_middleware()
+    ttl = middleware._read_resource_settings.get("ttl")
+    assert ttl is not None, "read_resource TTL should be set explicitly"
+    assert 0 < ttl <= 120, f"read_resource TTL too long for discovery: {ttl}"


### PR DESCRIPTION
## Summary

Phase 3 of the v3 modernization (#154). Wires fastmcp 3.x's built-in \`ResponseCachingMiddleware\` on the production server so catalog reads (products, customers, suppliers, locations) cache at the tool boundary without per-tool changes.

### Configuration

- **5-minute TTL on \`call_tool\`** — bounds the staleness window for read tools.
- **60-second TTL on \`read_resource\`** — resources are discovery-oriented, freshness wins.
- **Mutating tools excluded by name** — every \`create_*\`, \`delete_*\`, \`set_*\`, \`configure_*\`, plus the workflow tools that mutate. Caching a mutation would be silent data loss; the exclusion list is the safety guard.
- **In-memory store via fastmcp's bundled \`MemoryStore\`** — no new dependency. \`py-key-value-aio\` is already a transitive of fastmcp 3.x. Operators swap to Redis/disk via a few lines (documented).

### Why this design

- Operators get the win for free — no per-tool decoration, no manual invalidation.
- Mutation tools don't poison the cache because they never read from it.
- Bounded TTL keeps the staleness window short enough that pair-programmer agents won't observe stale state in practice.
- The whole thing is one middleware registration; operators who don't want it remove it (one-liner). See \`docs/mcp-server/observability.md\`.

### Documentation

\`docs/mcp-server/observability.md\` gains a \"Caching\" section with the TTL table, a Redis swap snippet, and three options for tightening freshness.

### Tests

\`stocktrim_mcp_server/tests/test_caching.py\` (4 tests) verifies our **wiring choices**: middleware is registered, every mutation surface is in the exclusion list, TTLs stay within bounded ranges. We don't re-test the middleware's caching behavior — that's fastmcp's responsibility.

## Test plan

- [x] \`uv run poe check\` passes — 73 client + 307 MCP = 380 tests (was 376; +4 new caching tests)
- [ ] CI matrix passes on Python 3.11/3.12/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)