### PR TITLE
feat(mcp): package server as MCPB (.mcpb) for one-click Claude Desktop install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,62 @@ jobs:
           name: dist-mcp
           path: mcp-dist/
 
+  build-mcpb:
+    name: Build MCPB bundle
+    needs: release-mcp
+    # Only build the .mcpb when the MCP server actually released — the bundle
+    # is an asset on the mcp-v* GitHub release created by python-semantic-release.
+    if: needs.release-mcp.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Pull the tag commit so the bundle picks up the version bump that
+          # release-mcp just pushed.
+          ref: ${{ needs.release-mcp.outputs.tag }}
+
+      # ``scripts/build_mcpb.py`` is stdlib-only and shells out to the ``mcpb``
+      # CLI — no project deps are needed for this job. Use setup-python
+      # instead of setup-uv so we don't pull in a project venv resolution we
+      # don't use.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Node.js (for mcpb CLI)
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install mcpb CLI
+        run: npm install -g @anthropic-ai/mcpb
+
+      - name: Build .mcpb bundle
+        id: build
+        run: |
+          artifact=$(python scripts/build_mcpb.py | tail -n 1)
+          echo "artifact=${artifact}" >> "$GITHUB_OUTPUT"
+          ls -la "${artifact}"
+
+      - name: Upload .mcpb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcpb
+          path: ${{ steps.build.outputs.artifact }}
+
+      - name: Attach .mcpb to GitHub release
+        # python-semantic-release created the release matching the mcp-v* tag
+        # in the release-mcp job. Upload the .mcpb as an additional asset on
+        # that release.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.release-mcp.outputs.tag }}" \
+            "${{ steps.build.outputs.artifact }}" --clobber
+
   publish-client:
     name: Publish Client to PyPI
     needs: release-client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,13 @@ jobs:
           node-version: "20"
 
       - name: Install mcpb CLI
-        run: npm install -g @anthropic-ai/mcpb
+        # Pin major version to avoid breaking changes from a future 3.x and to
+        # narrow the supply-chain surface — the .mcpb artifact this CLI builds
+        # is attached to a public GitHub release, so a compromised dependency
+        # would ship to end users. Bump deliberately when a new feature is
+        # needed; the published manifest_version (0.4) is independent of the
+        # CLI version.
+        run: npm install -g @anthropic-ai/mcpb@^2.1.2
 
       - name: Build .mcpb bundle
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Build .mcpb bundle
         id: build
         run: |
-          artifact=$(python scripts/build_mcpb.py | tail -n 1)
+          artifact=$(python scripts/build_mcpb.py)
           echo "artifact=${artifact}" >> "$GITHUB_OUTPUT"
           ls -la "${artifact}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -353,6 +353,15 @@ validate-openapi = "openapi-spec-validator stocktrim-openapi.yaml"
 validate-openapi-redocly = "npx @redocly/cli lint stocktrim-openapi.yaml"
 
 # -----------------------------------------------------------------------------
+# MCP Bundle (.mcpb) Build
+# -----------------------------------------------------------------------------
+# Produces ``dist/stocktrim-mcp-server-<version>.mcpb`` for one-click install
+# in Claude Desktop. Requires the ``mcpb`` CLI on PATH:
+#   npm install -g @anthropic-ai/mcpb
+# CI installs it on demand; locally, install once with the command above.
+build-mcpb = "python scripts/build_mcpb.py"
+
+# -----------------------------------------------------------------------------
 # Documentation Tasks
 # -----------------------------------------------------------------------------
 docs-build = "mkdocs build"

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Build the StockTrim MCP server as an MCP Bundle (``.mcpb``).
+
+The MCP Bundle format (formerly DXT) is Claude Desktop's one-click install
+package for local MCP servers. See https://github.com/anthropics/mcpb.
+
+Pipeline:
+
+1. Read the package version from ``stocktrim_mcp_server/pyproject.toml``.
+2. Stage a self-contained bundle directory under ``build/mcpb/`` containing:
+
+   - ``manifest.json``           — derived from
+     ``stocktrim_mcp_server/mcpb/manifest.template.json`` with ``__VERSION__``
+     substituted.
+   - ``pyproject.toml``          — derived from
+     ``stocktrim_mcp_server/mcpb/pyproject.template.toml`` with ``__VERSION__``
+     substituted; production deps mirrored from the package's own
+     ``pyproject.toml`` minus the workspace source ref. Mirroring is
+     verified — drift between the two files fails the build loudly.
+   - ``.mcpbignore``             — copied as-is.
+   - ``src/stocktrim_mcp_server/`` — copied from
+     ``stocktrim_mcp_server/src/stocktrim_mcp_server/``.
+   - ``README.md``               — copied from the package's own README.
+
+3. Validate ``manifest.json`` against the MCPB schema via ``mcpb validate``.
+4. Run ``mcpb pack build/mcpb dist/stocktrim-mcp-server-<version>.mcpb`` to
+   produce the final ``.mcpb`` artifact.
+
+Requires the ``mcpb`` CLI on PATH (``npm install -g @anthropic-ai/mcpb``).
+Outputs the artifact path on stdout — release CI uses that as the upload path.
+
+Env: ``MCPB_SKIP_PACK=1`` stages the bundle but skips ``mcpb pack`` (handy when
+the CLI isn't installed locally — CI installs it on demand).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_ROOT = REPO_ROOT / "stocktrim_mcp_server"
+PKG_PYPROJECT = PKG_ROOT / "pyproject.toml"
+PKG_SRC = PKG_ROOT / "src" / "stocktrim_mcp_server"
+PKG_README = PKG_ROOT / "README.md"
+
+MCPB_DIR = PKG_ROOT / "mcpb"
+MANIFEST_TEMPLATE = MCPB_DIR / "manifest.template.json"
+PYPROJECT_TEMPLATE = MCPB_DIR / "pyproject.template.toml"
+MCPBIGNORE = MCPB_DIR / ".mcpbignore"
+
+BUILD_DIR = REPO_ROOT / "build" / "mcpb"
+DIST_DIR = REPO_ROOT / "dist"
+
+VERSION_PLACEHOLDER = "__VERSION__"
+
+
+def read_pkg_pyproject() -> dict[str, Any]:
+    with PKG_PYPROJECT.open("rb") as f:
+        return tomllib.load(f)
+
+
+def get_pkg_version(pyproject: dict[str, Any]) -> str:
+    version = pyproject.get("project", {}).get("version")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError(f"Could not read [project.version] from {PKG_PYPROJECT}")
+    return version
+
+
+def verify_dep_mirror(pkg_pyproject: dict[str, Any]) -> None:
+    """Fail loudly if the bundle pyproject's deps drift from the package's.
+
+    The bundle template hand-copies the production deps so that we can omit the
+    workspace ``[tool.uv.sources]`` ref (which only resolves inside the
+    monorepo). When new deps are added to the package, the template must be
+    updated to match — otherwise the bundle would silently miss them at
+    runtime.
+    """
+    with PYPROJECT_TEMPLATE.open("rb") as f:
+        bundle_pyproject = tomllib.load(f)
+
+    pkg_deps = set(pkg_pyproject.get("project", {}).get("dependencies", []))
+    bundle_deps = set(bundle_pyproject.get("project", {}).get("dependencies", []))
+
+    missing_from_bundle = pkg_deps - bundle_deps
+    extra_in_bundle = bundle_deps - pkg_deps
+
+    if missing_from_bundle or extra_in_bundle:
+        msg = ["Bundle pyproject.template.toml is out of sync with the package's."]
+        if missing_from_bundle:
+            msg.append("  Missing from bundle (add to template):")
+            msg.extend(f"    - {dep}" for dep in sorted(missing_from_bundle))
+        if extra_in_bundle:
+            msg.append("  Extra in bundle (remove from template):")
+            msg.extend(f"    - {dep}" for dep in sorted(extra_in_bundle))
+        raise RuntimeError("\n".join(msg))
+
+
+def substitute(template: str, version: str) -> str:
+    return template.replace(VERSION_PLACEHOLDER, version)
+
+
+def stage_bundle(version: str) -> None:
+    if BUILD_DIR.exists():
+        shutil.rmtree(BUILD_DIR)
+    BUILD_DIR.mkdir(parents=True)
+
+    # Force UTF-8 + LF on read and write — templates contain non-ASCII chars
+    # (em-dash, arrow). Default encoding is locale-dependent; on a non-UTF-8
+    # locale (Windows ``cp1252``) the round-trip silently corrupts manifest
+    # text and the bundle ships with garbled metadata.
+    (BUILD_DIR / "manifest.json").write_text(
+        substitute(MANIFEST_TEMPLATE.read_text(encoding="utf-8"), version),
+        encoding="utf-8",
+        newline="\n",
+    )
+    (BUILD_DIR / "pyproject.toml").write_text(
+        substitute(PYPROJECT_TEMPLATE.read_text(encoding="utf-8"), version),
+        encoding="utf-8",
+        newline="\n",
+    )
+    shutil.copy2(MCPBIGNORE, BUILD_DIR / ".mcpbignore")
+
+    src_dest = BUILD_DIR / "src" / "stocktrim_mcp_server"
+    shutil.copytree(
+        PKG_SRC,
+        src_dest,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"),
+    )
+
+    if PKG_README.exists():
+        shutil.copy2(PKG_README, BUILD_DIR / "README.md")
+
+
+def run_mcpb_validate() -> None:
+    subprocess.run(
+        ["mcpb", "validate", str(BUILD_DIR / "manifest.json")],
+        check=True,
+    )
+
+
+def run_mcpb_pack(version: str) -> Path:
+    DIST_DIR.mkdir(exist_ok=True)
+    artifact = DIST_DIR / f"stocktrim-mcp-server-{version}.mcpb"
+    if artifact.exists():
+        artifact.unlink()
+    subprocess.run(
+        ["mcpb", "pack", str(BUILD_DIR), str(artifact)],
+        check=True,
+    )
+    return artifact
+
+
+def main() -> int:
+    pyproject = read_pkg_pyproject()
+    version = get_pkg_version(pyproject)
+    verify_dep_mirror(pyproject)
+    stage_bundle(version)
+
+    if os.environ.get("MCPB_SKIP_PACK") == "1":
+        print(BUILD_DIR, file=sys.stdout)
+        return 0
+
+    run_mcpb_validate()
+    artifact = run_mcpb_pack(version)
+    print(artifact, file=sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -105,25 +105,25 @@ def substitute(template: str, version: str) -> str:
     return template.replace(VERSION_PLACEHOLDER, version)
 
 
+def _write_substituted(src: Path, dest: Path, version: str) -> None:
+    # Force UTF-8 + LF on read and write — templates contain non-ASCII chars
+    # (em-dash, arrow). Default encoding is locale-dependent; on a non-UTF-8
+    # locale (Windows ``cp1252``) the round-trip silently corrupts manifest
+    # text and the bundle ships with garbled metadata.
+    dest.write_text(
+        substitute(src.read_text(encoding="utf-8"), version),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
 def stage_bundle(version: str) -> None:
     if BUILD_DIR.exists():
         shutil.rmtree(BUILD_DIR)
     BUILD_DIR.mkdir(parents=True)
 
-    # Force UTF-8 + LF on read and write — templates contain non-ASCII chars
-    # (em-dash, arrow). Default encoding is locale-dependent; on a non-UTF-8
-    # locale (Windows ``cp1252``) the round-trip silently corrupts manifest
-    # text and the bundle ships with garbled metadata.
-    (BUILD_DIR / "manifest.json").write_text(
-        substitute(MANIFEST_TEMPLATE.read_text(encoding="utf-8"), version),
-        encoding="utf-8",
-        newline="\n",
-    )
-    (BUILD_DIR / "pyproject.toml").write_text(
-        substitute(PYPROJECT_TEMPLATE.read_text(encoding="utf-8"), version),
-        encoding="utf-8",
-        newline="\n",
-    )
+    _write_substituted(MANIFEST_TEMPLATE, BUILD_DIR / "manifest.json", version)
+    _write_substituted(PYPROJECT_TEMPLATE, BUILD_DIR / "pyproject.toml", version)
     shutil.copy2(MCPBIGNORE, BUILD_DIR / ".mcpbignore")
 
     src_dest = BUILD_DIR / "src" / "stocktrim_mcp_server"
@@ -132,9 +132,7 @@ def stage_bundle(version: str) -> None:
         src_dest,
         ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"),
     )
-
-    if PKG_README.exists():
-        shutil.copy2(PKG_README, BUILD_DIR / "README.md")
+    shutil.copy2(PKG_README, BUILD_DIR / "README.md")
 
 
 def run_mcpb_validate() -> None:
@@ -147,8 +145,7 @@ def run_mcpb_validate() -> None:
 def run_mcpb_pack(version: str) -> Path:
     DIST_DIR.mkdir(exist_ok=True)
     artifact = DIST_DIR / f"stocktrim-mcp-server-{version}.mcpb"
-    if artifact.exists():
-        artifact.unlink()
+    artifact.unlink(missing_ok=True)
     subprocess.run(
         ["mcpb", "pack", str(BUILD_DIR), str(artifact)],
         check=True,

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -182,9 +182,14 @@ def stage_bundle(version: str, client_dep: str) -> None:
 
 
 def run_mcpb_validate() -> None:
+    # Redirect the CLI's stdout to stderr so this script's stdout stays
+    # machine-readable — CI captures the artifact path via
+    # ``artifact=$(python scripts/build_mcpb.py)`` and any progress line the
+    # ``mcpb`` CLI emits would otherwise contaminate that capture.
     subprocess.run(
         ["mcpb", "validate", str(BUILD_DIR / "manifest.json")],
         check=True,
+        stdout=sys.stderr,
     )
 
 
@@ -195,6 +200,7 @@ def run_mcpb_pack(version: str) -> Path:
     subprocess.run(
         ["mcpb", "pack", str(BUILD_DIR), str(artifact)],
         check=True,
+        stdout=sys.stderr,
     )
     return artifact
 

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -58,6 +58,8 @@ BUILD_DIR = REPO_ROOT / "build" / "mcpb"
 DIST_DIR = REPO_ROOT / "dist"
 
 VERSION_PLACEHOLDER = "__VERSION__"
+CLIENT_DEP_PLACEHOLDER = "__STOCKTRIM_CLIENT_DEP__"
+CLIENT_PKG_NAME = "stocktrim-openapi-client"
 
 
 def read_pkg_pyproject() -> dict[str, Any]:
@@ -72,6 +74,37 @@ def get_pkg_version(pyproject: dict[str, Any]) -> str:
     return version
 
 
+def get_client_dep(pyproject: dict[str, Any]) -> str:
+    """Return the package's ``stocktrim-openapi-client`` requirement string.
+
+    On a real MCP release the workflow rewrites this to
+    ``stocktrim-openapi-client==<version>`` before tagging, so the bundle must
+    carry the same pin to keep ``verify_dep_mirror`` honest. Returning the
+    raw requirement string (rather than just a version) keeps the substitution
+    transparent — whatever the package depends on, the bundle depends on.
+    """
+    for dep in pyproject.get("project", {}).get("dependencies", []):
+        if (
+            dep.split("[", 1)[0]
+            .split("=", 1)[0]
+            .split("<", 1)[0]
+            .split(">", 1)[0]
+            .strip()
+            == CLIENT_PKG_NAME
+        ):
+            return dep
+    raise RuntimeError(
+        f"Could not find a `{CLIENT_PKG_NAME}` requirement in {PKG_PYPROJECT}"
+    )
+
+
+def substitute(template: str, replacements: dict[str, str]) -> str:
+    result = template
+    for placeholder, value in replacements.items():
+        result = result.replace(placeholder, value)
+    return result
+
+
 def verify_dep_mirror(pkg_pyproject: dict[str, Any]) -> None:
     """Fail loudly if the bundle pyproject's deps drift from the package's.
 
@@ -80,9 +113,18 @@ def verify_dep_mirror(pkg_pyproject: dict[str, Any]) -> None:
     monorepo). When new deps are added to the package, the template must be
     updated to match — otherwise the bundle would silently miss them at
     runtime.
+
+    The ``stocktrim-openapi-client`` line is special-cased: the template carries
+    a placeholder that the build script substitutes at pack time, so the mirror
+    check parses the template *after* substitution. This keeps the check valid
+    when the release workflow pins the client dep to an exact version.
     """
-    with PYPROJECT_TEMPLATE.open("rb") as f:
-        bundle_pyproject = tomllib.load(f)
+    client_dep = get_client_dep(pkg_pyproject)
+    substituted = substitute(
+        PYPROJECT_TEMPLATE.read_text(encoding="utf-8"),
+        {CLIENT_DEP_PLACEHOLDER: client_dep},
+    )
+    bundle_pyproject = tomllib.loads(substituted)
 
     pkg_deps = set(pkg_pyproject.get("project", {}).get("dependencies", []))
     bundle_deps = set(bundle_pyproject.get("project", {}).get("dependencies", []))
@@ -101,29 +143,33 @@ def verify_dep_mirror(pkg_pyproject: dict[str, Any]) -> None:
         raise RuntimeError("\n".join(msg))
 
 
-def substitute(template: str, version: str) -> str:
-    return template.replace(VERSION_PLACEHOLDER, version)
-
-
-def _write_substituted(src: Path, dest: Path, version: str) -> None:
+def _write_substituted(src: Path, dest: Path, replacements: dict[str, str]) -> None:
     # Force UTF-8 + LF on read and write — templates contain non-ASCII chars
     # (em-dash, arrow). Default encoding is locale-dependent; on a non-UTF-8
     # locale (Windows ``cp1252``) the round-trip silently corrupts manifest
     # text and the bundle ships with garbled metadata.
     dest.write_text(
-        substitute(src.read_text(encoding="utf-8"), version),
+        substitute(src.read_text(encoding="utf-8"), replacements),
         encoding="utf-8",
         newline="\n",
     )
 
 
-def stage_bundle(version: str) -> None:
+def stage_bundle(version: str, client_dep: str) -> None:
     if BUILD_DIR.exists():
         shutil.rmtree(BUILD_DIR)
     BUILD_DIR.mkdir(parents=True)
 
-    _write_substituted(MANIFEST_TEMPLATE, BUILD_DIR / "manifest.json", version)
-    _write_substituted(PYPROJECT_TEMPLATE, BUILD_DIR / "pyproject.toml", version)
+    _write_substituted(
+        MANIFEST_TEMPLATE,
+        BUILD_DIR / "manifest.json",
+        {VERSION_PLACEHOLDER: version},
+    )
+    _write_substituted(
+        PYPROJECT_TEMPLATE,
+        BUILD_DIR / "pyproject.toml",
+        {VERSION_PLACEHOLDER: version, CLIENT_DEP_PLACEHOLDER: client_dep},
+    )
     shutil.copy2(MCPBIGNORE, BUILD_DIR / ".mcpbignore")
 
     src_dest = BUILD_DIR / "src" / "stocktrim_mcp_server"
@@ -156,8 +202,9 @@ def run_mcpb_pack(version: str) -> Path:
 def main() -> int:
     pyproject = read_pkg_pyproject()
     version = get_pkg_version(pyproject)
+    client_dep = get_client_dep(pyproject)
     verify_dep_mirror(pyproject)
-    stage_bundle(version)
+    stage_bundle(version, client_dep)
 
     if os.environ.get("MCPB_SKIP_PACK") == "1":
         print(BUILD_DIR, file=sys.stdout)

--- a/stocktrim_mcp_server/README.md
+++ b/stocktrim_mcp_server/README.md
@@ -25,7 +25,7 @@ management, customer data, and inventory control.
 - **Type-Safe**: Full type hints with Pydantic validation for all operations
   ([ADR 002](../docs/architecture/decisions/002-tool-interface-pattern.md))
 - **Production-Ready**: Built-in error handling, logging, and resilience
-- **FastMCP**: Leverages FastMCP 2.11.0 for high-performance MCP implementation
+- **FastMCP**: Built on FastMCP v3 for high-performance MCP implementation
 
 ## Installation
 

--- a/stocktrim_mcp_server/README.md
+++ b/stocktrim_mcp_server/README.md
@@ -73,11 +73,24 @@ STOCKTRIM_BASE_URL=https://api.stocktrim.com  # Default
 
 ## Claude Desktop Integration
 
-To use this MCP server with Claude Desktop, add it to your Claude configuration:
+**Recommended: install the `.mcpb` bundle** — Claude Desktop has built-in support for
+[MCP Bundles](https://github.com/anthropics/mcpb), which install local MCP servers in
+one click and prompt for the API credentials via UI (no JSON editing).
 
-### On macOS
+1. Download `stocktrim-mcp-server-<version>.mcpb` from the
+   [latest GitHub release](https://github.com/dougborg/stocktrim-openapi-client/releases?q=mcp-v).
+1. Drag the `.mcpb` file into Claude Desktop, or open it from the Finder.
+1. Confirm install in the dialog. Claude Desktop prompts for both your StockTrim **Auth
+   ID** (Tenant ID) and **Auth Signature** (Tenant Name); both are stored securely and
+   never written to a config file by hand.
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+The bundle ships the server source plus a manifest that declares the runtime
+requirements; UV handles dep resolution on first launch.
+
+### Manual `uvx` install (fallback)
+
+If you'd rather edit `~/Library/Application Support/Claude/claude_desktop_config.json`
+(or `%APPDATA%\Claude\claude_desktop_config.json` on Windows) directly:
 
 ```json
 {
@@ -93,10 +106,6 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
   }
 }
 ```
-
-### On Windows
-
-Edit `%APPDATA%\Claude\claude_desktop_config.json` with the same configuration.
 
 ### Using Python Environment
 
@@ -117,7 +126,8 @@ If you have the server installed in a specific Python environment:
 }
 ```
 
-After configuring, restart Claude Desktop for changes to take effect.
+Either path: restart Claude Desktop after configuring and the StockTrim tools will
+appear.
 
 ## Available Tools
 

--- a/stocktrim_mcp_server/README.md
+++ b/stocktrim_mcp_server/README.md
@@ -116,7 +116,7 @@ If you have the server installed in a specific Python environment:
   "mcpServers": {
     "stocktrim": {
       "command": "python",
-      "args": ["-m", "stocktrim_mcp_server"],
+      "args": ["-m", "stocktrim_mcp_server.server"],
       "env": {
         "STOCKTRIM_API_AUTH_ID": "your_tenant_id_here",
         "STOCKTRIM_API_AUTH_SIGNATURE": "your_tenant_name_here"

--- a/stocktrim_mcp_server/mcpb/.mcpbignore
+++ b/stocktrim_mcp_server/mcpb/.mcpbignore
@@ -1,0 +1,18 @@
+# Files excluded from the .mcpb archive when ``mcpb pack`` runs against the
+# build/mcpb/ staging directory. The CLI already excludes a default set
+# (.git, node_modules, .DS_Store, .vscode, etc.); this list adds project-
+# specific noise.
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+.coverage.*
+htmlcov/
+.venv/
+*.egg-info/
+build/
+dist/
+tests/

--- a/stocktrim_mcp_server/mcpb/manifest.template.json
+++ b/stocktrim_mcp_server/mcpb/manifest.template.json
@@ -1,0 +1,62 @@
+{
+  "manifest_version": "0.4",
+  "name": "stocktrim-mcp-server",
+  "display_name": "StockTrim",
+  "version": "__VERSION__",
+  "description": "MCP server for the StockTrim Inventory Management API — products, customers, suppliers, inventory, and purchase orders from Claude Desktop.",
+  "long_description": "Exposes the StockTrim public API as MCP tools. Includes product search and lookup, customer and supplier management, inventory level updates, and purchase / sales order workflows. Two-credential header auth (Tenant ID + Tenant Name). Transport layer adds automatic retries on idempotent 5xx errors and detailed error logging.",
+  "author": {
+    "name": "Doug Borg",
+    "email": "dougborg@dougborg.org",
+    "url": "https://github.com/dougborg"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dougborg/stocktrim-openapi-client.git"
+  },
+  "homepage": "https://github.com/dougborg/stocktrim-openapi-client",
+  "documentation": "https://dougborg.github.io/stocktrim-openapi-client/",
+  "support": "https://github.com/dougborg/stocktrim-openapi-client/issues",
+  "license": "MIT",
+  "keywords": ["stocktrim", "inventory", "mcp", "claude", "products", "orders"],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/stocktrim_mcp_server/server.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "stocktrim-mcp-server"
+      ],
+      "env": {
+        "STOCKTRIM_API_AUTH_ID": "${user_config.auth_id}",
+        "STOCKTRIM_API_AUTH_SIGNATURE": "${user_config.auth_signature}"
+      }
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "linux", "win32"],
+    "runtimes": {
+      "python": ">=3.11,<3.14"
+    }
+  },
+  "user_config": {
+    "auth_id": {
+      "type": "string",
+      "title": "StockTrim Auth ID",
+      "description": "Your StockTrim Tenant ID. Find it under Settings → API Settings in the StockTrim web app.",
+      "required": true,
+      "sensitive": true
+    },
+    "auth_signature": {
+      "type": "string",
+      "title": "StockTrim Auth Signature",
+      "description": "Your StockTrim Tenant Name (used as the API auth signature). Find it under Settings → API Settings in the StockTrim web app.",
+      "required": true,
+      "sensitive": true
+    }
+  }
+}

--- a/stocktrim_mcp_server/mcpb/pyproject.template.toml
+++ b/stocktrim_mcp_server/mcpb/pyproject.template.toml
@@ -1,0 +1,32 @@
+# Bundle pyproject.toml for the .mcpb artifact — do NOT edit this directly to
+# add deps. The build script (scripts/build_mcpb.py) substitutes ``__VERSION__``
+# from the package's own pyproject.toml at pack time. Production runtime deps
+# are mirrored from ``stocktrim_mcp_server/pyproject.toml`` and must stay in
+# sync; the build script verifies this and fails loudly on drift.
+#
+# This file deliberately omits the ``[tool.uv.sources]`` workspace ref — the
+# bundle resolves ``stocktrim-openapi-client`` from PyPI, since the workspace
+# doesn't exist on the user's machine.
+[project]
+name = "stocktrim-mcp-server"
+version = "__VERSION__"
+description = "MCP server for the StockTrim Inventory Management API"
+requires-python = ">=3.11,<3.14"
+dependencies = [
+  "stocktrim-openapi-client",
+  "fastmcp>=3.0.0,<4.0.0",
+  "python-dotenv>=1.0.0",
+  "structlog>=24.1.0",
+  # Markdown templates for ToolResult rendering
+  "jinja2>=3.1.0,<4.0.0",
+]
+
+[project.scripts]
+stocktrim-mcp-server = "stocktrim_mcp_server.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/stocktrim_mcp_server"]

--- a/stocktrim_mcp_server/mcpb/pyproject.template.toml
+++ b/stocktrim_mcp_server/mcpb/pyproject.template.toml
@@ -1,8 +1,18 @@
 # Bundle pyproject.toml for the .mcpb artifact — do NOT edit this directly to
-# add deps. The build script (scripts/build_mcpb.py) substitutes ``__VERSION__``
-# from the package's own pyproject.toml at pack time. Production runtime deps
-# are mirrored from ``stocktrim_mcp_server/pyproject.toml`` and must stay in
-# sync; the build script verifies this and fails loudly on drift.
+# add deps. The build script (scripts/build_mcpb.py) substitutes two
+# placeholders at pack time:
+#
+#   __VERSION__                — the bundle's own version, from the package
+#                                pyproject's ``[project.version]``.
+#   __STOCKTRIM_CLIENT_DEP__   — the full ``stocktrim-openapi-client`` PEP 508
+#                                requirement string from the package pyproject.
+#                                During an MCP release the workflow rewrites
+#                                this to ``stocktrim-openapi-client==<X.Y.Z>``,
+#                                so the bundle must carry the exact same pin
+#                                or ``verify_dep_mirror`` will reject the build.
+#
+# Production runtime deps are mirrored from ``stocktrim_mcp_server/pyproject.toml``
+# and must stay in sync; the build script verifies this and fails loudly on drift.
 #
 # This file deliberately omits the ``[tool.uv.sources]`` workspace ref — the
 # bundle resolves ``stocktrim-openapi-client`` from PyPI, since the workspace
@@ -13,7 +23,7 @@ version = "__VERSION__"
 description = "MCP server for the StockTrim Inventory Management API"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-  "stocktrim-openapi-client",
+  "__STOCKTRIM_CLIENT_DEP__",
   "fastmcp>=3.0.0,<4.0.0",
   "python-dotenv>=1.0.0",
   "structlog>=24.1.0",


### PR DESCRIPTION
## Summary

Packages ``stocktrim-mcp-server`` as an [MCP Bundle](https://github.com/anthropics/mcpb) (formerly DXT) — Claude Desktop's one-click install format. Closes #160.

Four files added under ``stocktrim_mcp_server/mcpb/`` plus ``scripts/build_mcpb.py`` orchestrator:

- **manifest.template.json** — ``manifest_version: "0.4"``, ``server.type: "uv"`` (UV runtime, ~89 kB bundles, no bundled interpreter). Two-credential ``user_config`` for ``auth_id`` + ``auth_signature`` so Claude Desktop prompts for both via UI.
- **pyproject.template.toml** — bundle's pyproject (deps mirrored from package, ``[tool.uv.sources]`` workspace ref omitted so deps resolve from PyPI).
- **.mcpbignore** — Python build excludes.
- **scripts/build_mcpb.py** — orchestrator. Reads version from package pyproject, **verifies dep mirroring and fails loudly on drift**, stages ``build/mcpb/``, runs ``mcpb validate`` + ``mcpb pack``. Stdlib-only.

Plus:

- ``uv run poe build-mcpb`` for local builds.
- ``build-mcpb`` job in ``.github/workflows/release.yml``, gated on ``release-mcp.outputs.released == 'true'``, attaches the artifact to the ``mcp-v*`` GitHub release via ``gh release upload --clobber``.
- README install section reorganized to lead with ``.mcpb`` flow; manual ``uvx`` config kept as labeled fallback.

## Differences from statuspro PR #62 (the reference implementation)

- **Two-credential ``user_config``** — StockTrim uses ``STOCKTRIM_API_AUTH_ID`` + ``STOCKTRIM_API_AUTH_SIGNATURE`` instead of a single bearer token, so the manifest declares both as separate sensitive-string prompts; ``mcp_config.env`` injects both.
- **Unified release workflow** — stocktrim has a single ``.github/workflows/release.yml`` with a ``release-mcp`` job (not a separate ``release-mcp.yml``), so the new ``build-mcpb`` job lives there too. It depends on ``release-mcp`` and reads ``needs.release-mcp.outputs.tag`` instead of parsing ``GITHUB_REF``.
- **Layout** — source is at ``stocktrim_mcp_server/src/stocktrim_mcp_server/`` (double-nested, not triple as the issue text implied). No ``__main__.py``, so manifest ``entry_point`` points at ``server.py``; the actual launch path is the ``stocktrim-mcp-server`` console script anyway.
- **Python range** — ``>=3.11,<3.14`` to match the package's ``requires-python``.

## Test plan

Local validation already done:

- [x] ``MCPB_SKIP_PACK=1 python scripts/build_mcpb.py`` — dep-mirror check passes, bundle staged.
- [x] ``python scripts/build_mcpb.py`` — manifest validates against MCPB schema, pack succeeds. Output: ``dist/stocktrim-mcp-server-0.15.1.mcpb``, **89.3 kB**, **50 files**.
- [x] ``mcpb info dist/stocktrim-mcp-server-0.15.1.mcpb`` — reports the bundle correctly.
- [x] **Smoke test**: ``cd build/mcpb && uv run --directory . stocktrim-mcp-server`` — UV resolves 78 packages from PyPI, FastMCP server launches end-to-end, all tools registered.
- [x] ``uv run poe check`` — 73 client tests + 309 MCP tests pass, lint/type/format clean.

CI to verify:

- [ ] ``test`` job passes.
- [ ] ``build-mcpb`` job is correctly gated (won't run on this PR since ``release-mcp.outputs.released`` is only ``true`` on tag-creating releases — that's expected; first real run will be on the next ``mcp-v*`` tag push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)