### PR TITLE
feat(client): allow httpx-retries 0.5.x and adopt total_timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "urllib3>=2.5.0,<4.0.0",
   "pydantic>=2,<3",
   "typing-extensions>=4.7.0",
-  "httpx-retries>=0.4.3,<0.5.0",
+  "httpx-retries>=0.5.0,<0.6.0",
 ]
 
 [project.urls]

--- a/stocktrim_public_api_client/stocktrim_client.py
+++ b/stocktrim_public_api_client/stocktrim_client.py
@@ -509,6 +509,7 @@ class AuthHeaderTransport(AsyncHTTPTransport):
 def create_resilient_transport(
     api_auth_signature: str,
     max_retries: int = 5,
+    total_retry_timeout: float | None = 60.0,
     logger: logging.Logger | None = None,
     **kwargs: Any,
 ) -> tuple[RetryTransport, ErrorLoggingTransport]:
@@ -528,6 +529,11 @@ def create_resilient_transport(
     Args:
         api_auth_signature: StockTrim API authentication signature
         max_retries: Maximum number of retry attempts for failed requests. Defaults to 5.
+        total_retry_timeout: Cumulative cap (seconds) on sleep time across retry
+            attempts for a single request. Stops further retries once exceeded,
+            even if ``max_retries`` would allow more. Defaults to 60s, which
+            comfortably covers full exponential backoff (1+2+4+8+16=31s) plus
+            slack for ``Retry-After`` headers; set ``None`` to disable.
         logger: Logger instance for capturing operations. If None, creates a default logger.
         **kwargs: Additional arguments passed to the base AsyncHTTPTransport.
             Common parameters include:
@@ -585,6 +591,7 @@ def create_resilient_transport(
     retry = IdempotentOnlyRetry(
         total=max_retries,
         backoff_factor=1.0,  # Exponential backoff: 1, 2, 4, 8, 16 seconds
+        total_timeout=total_retry_timeout,  # Cumulative cap on retry sleep time
         respect_retry_after_header=True,  # Honor server's Retry-After header if present
         status_forcelist=[502, 503, 504],  # Only 5xx server errors (no 429)
         allowed_methods=[
@@ -649,6 +656,7 @@ class StockTrimClient(AuthenticatedClient):
         base_url: str | None = None,
         timeout: float = 30.0,
         max_retries: int = 5,
+        total_retry_timeout: float | None = 60.0,
         logger: logging.Logger | None = None,
         **httpx_kwargs: Any,
     ):
@@ -663,6 +671,8 @@ class StockTrimClient(AuthenticatedClient):
             base_url: Base URL for the StockTrim API. Defaults to https://api.stocktrim.com
             timeout: Request timeout in seconds. Defaults to 30.0.
             max_retries: Maximum number of retry attempts for failed requests. Defaults to 5.
+            total_retry_timeout: Cumulative cap (seconds) on sleep time across retry
+                attempts for a single request. Defaults to 60s; pass ``None`` to disable.
             logger: Logger instance for capturing client operations. If None, creates a default logger.
             **httpx_kwargs: Additional arguments passed to the base AsyncHTTPTransport.
                 Common parameters include:
@@ -706,6 +716,7 @@ class StockTrimClient(AuthenticatedClient):
 
         self.logger = logger or logging.getLogger(__name__)
         self.max_retries = max_retries
+        self.total_retry_timeout = total_retry_timeout
 
         # Extract client-level parameters that shouldn't go to the transport
         # Event hooks for observability - start with our defaults
@@ -734,6 +745,7 @@ class StockTrimClient(AuthenticatedClient):
         transport, error_logging_transport = create_resilient_transport(
             api_auth_signature=api_auth_signature,
             max_retries=max_retries,
+            total_retry_timeout=total_retry_timeout,
             logger=self.logger,
             **httpx_kwargs,  # Pass through http2, limits, verify, etc.
         )
@@ -892,7 +904,8 @@ class StockTrimClient(AuthenticatedClient):
         """String representation of the client."""
         return (
             f"StockTrimClient(base_url='{self._base_url}', "
-            f"max_retries={self.max_retries})"
+            f"max_retries={self.max_retries}, "
+            f"total_retry_timeout={self.total_retry_timeout})"
         )
 
 

--- a/tests/test_stocktrim_client.py
+++ b/tests/test_stocktrim_client.py
@@ -23,6 +23,15 @@ class TestStockTrimClient:
         assert isinstance(client, StockTrimClient)
         assert client.base_url == "https://api.test.stocktrim.example.com"
         assert client.max_retries == 5
+        assert client.total_retry_timeout == 60.0
+
+    def test_client_total_retry_timeout_overridable(self, mock_api_credentials):
+        """Custom total_retry_timeout (incl. None to disable) is honored."""
+        bounded = StockTrimClient(**mock_api_credentials, total_retry_timeout=15.0)
+        assert bounded.total_retry_timeout == 15.0
+
+        unbounded = StockTrimClient(**mock_api_credentials, total_retry_timeout=None)
+        assert unbounded.total_retry_timeout is None
 
     def test_client_initialization_from_env(self, mock_env_credentials):
         """Test client can be initialized from environment variables."""
@@ -53,6 +62,7 @@ class TestStockTrimClient:
         assert "StockTrimClient" in repr_str
         assert "base_url" in repr_str
         assert "max_retries" in repr_str
+        assert "total_retry_timeout" in repr_str
 
     @pytest.mark.asyncio
     async def test_client_context_manager(self, stocktrim_client):

--- a/uv.lock
+++ b/uv.lock
@@ -672,14 +672,14 @@ wheels = [
 
 [[package]]
 name = "httpx-retries"
-version = "0.4.5"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/40/b9b5e4c16fb86d2999840bb795b28670a61856c7f48f030530b412bf4133/httpx_retries-0.4.5.tar.gz", hash = "sha256:acee306d7384eefad71ac12fefe8b13d7b41c19595c538e68d9bd7e40e59539d", size = 13015, upload-time = "2025-10-17T15:55:23.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/f5/046cac13877ce9b55aebdbb3999e0e45b19b989a95c5fd1040fa04bd1f92/httpx_retries-0.5.0.tar.gz", hash = "sha256:d8c8e1e0852d84be3837aba0bcf78aeb89a4b77db95e8cc988c8c058830b3044", size = 15647, upload-time = "2026-04-20T01:21:47.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/0a/2626b5a2678f8072ba3174d3e40f81429fdc41d1cb993280dbc7ba3c4e3f/httpx_retries-0.4.5-py3-none-any.whl", hash = "sha256:ae22d6ef197a2da49242246a01d721474cbd6516b1fef155f6da694ee410bb37", size = 8301, upload-time = "2025-10-17T15:55:22.869Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a8/aadeaa9a28510727d538636ee8688f0782a98523147852b29404ce696f1b/httpx_retries-0.5.0-py3-none-any.whl", hash = "sha256:d3124592979a9dc6197e666d1f02e9ab996a0c58fce59fad8db6201a6a87304e", size = 8908, upload-time = "2026-04-20T01:21:46.157Z" },
 ]
 
 [[package]]
@@ -2212,7 +2212,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=22.2.0" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "httpx-retries", specifier = ">=0.4.3,<0.5.0" },
+    { name = "httpx-retries", specifier = ">=0.5.0,<0.6.0" },
     { name = "mdformat", marker = "extra == 'dev'", specifier = ">=0.7.17" },
     { name = "mdformat-gfm", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "mdformat-tables", marker = "extra == 'dev'", specifier = ">=0.4.0" },


### PR DESCRIPTION
## Summary

Frees us from the only direct pin in `pyproject.toml` that was actively blocking a current release (`httpx-retries<0.5.0`), and adopts the new `total_timeout` parameter so retry sleep is bounded.

- **Bump**: `httpx-retries>=0.4.3,<0.5.0` → `httpx-retries>=0.5.0,<0.6.0` (lockfile lands 0.5.0).
- **Adopt**: `create_resilient_transport` and `StockTrimClient.__init__` gain a `total_retry_timeout: float | None = 60.0` kwarg. 60s comfortably covers full exponential backoff (1+2+4+8+16=31s) plus `Retry-After` slack, while bounding pathological "server keeps returning 5xx with 60s Retry-After" cases. Pass `None` to disable.
- **`__repr__`** now includes the new attribute.

### Compatibility notes for `httpx-retries` 0.5.0

- Drops Python 3.9 support — we already require 3.11+, so no impact.
- `allowed_methods` now stores uppercase strings instead of `http.HTTPMethod` enum members. Our `IdempotentOnlyRetry.is_retryable_method` already uppercases the comparand (`self._current_method = method.upper()`) before the membership check, so no behavioral change.
- `Retry.increment()` / `is_retryable_method` / `is_retryable_status_code` public signatures unchanged.

## Test plan

- [x] `uv run poe check` — lint, ty, ruff, yamllint, 75 client tests (2 new) + 309 MCP tests
- [x] New test verifies the default `60.0`, an explicit override, and `total_retry_timeout=None`
- [x] Existing `__repr__` test extended to assert the new attribute appears
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)