### PR TITLE
chore: housekeeping — fix uv workspace install (#172) and clean up docs build warnings (#173)

### DIFF
--- a/docs/mcp-server/examples.md
+++ b/docs/mcp-server/examples.md
@@ -10,7 +10,7 @@ to use each approach.
 - [Workflow 2: Forecast Management and Analysis](#workflow-2-forecast-management-and-analysis)
 - [Workflow 3: New Supplier Onboarding](#workflow-3-new-supplier-onboarding)
 - [Workflow 4: Product Lifecycle Management](#workflow-4-product-lifecycle-management)
-- [Workflow 5: Custom Order Fulfillment](#workflow-5-custom-order-fulfillment)
+- [Workflow 5: Customer Order Fulfillment](#workflow-5-customer-order-fulfillment)
 - [Advanced Patterns](#advanced-patterns)
 
 ______________________________________________________________________
@@ -911,5 +911,6 @@ ______________________________________________________________________
 
 - Review [MCP Server Tools Reference](./tools.md) for complete API documentation
 - See [Observability Guide](./observability.md) for OTel + middleware setup
-- Check [FastMCP Documentation](https://github.com/PrefectHQ/fastmcp) for server internals
+- Check [FastMCP Documentation](https://github.com/PrefectHQ/fastmcp) for server
+  internals
 - Report issues at https://github.com/dougborg/stocktrim-openapi-client/issues

--- a/docs/mcp-server/overview.md
+++ b/docs/mcp-server/overview.md
@@ -377,7 +377,8 @@ MIT License - see LICENSE file for details
 
 ## Related Projects
 
-- [stocktrim-openapi-client](../README.md): Python client library for StockTrim API
+- [stocktrim-openapi-client](https://github.com/dougborg/stocktrim-openapi-client/blob/main/README.md):
+  Python client library for StockTrim API
 - [FastMCP](https://github.com/jlowin/fastmcp): High-performance MCP server framework
 
 ## Changelog

--- a/docs/mcp-server/prompts.md
+++ b/docs/mcp-server/prompts.md
@@ -321,10 +321,10 @@ slow-moving or obsolete items, and making lifecycle decisions.
 
 #### Parameters
 
-| Parameter         | Type    | Required | Default   | Description                                 |
-|-------------------|---------|----------|-----------|---------------------------------------------|
-| category          | str     | No       | "all"     | Product category to review                  |
-| include_inactive  | bool    | No       | False     | Include discontinued/inactive products      |
+| Parameter        | Type | Required | Default | Description                            |
+| ---------------- | ---- | -------- | ------- | -------------------------------------- |
+| category         | str  | No       | "all"   | Product category to review             |
+| include_inactive | bool | No       | False   | Include discontinued/inactive products |
 
 #### Workflow Steps
 
@@ -501,7 +501,8 @@ To add a new prompt:
 ## Related Documentation
 
 - [Available Tools](./tools.md) - MCP tools used by prompts
-- [Resources](./overview.md#resources) - Read-only data resources
+- [MCP Resources Specification](https://modelcontextprotocol.io/docs/concepts/resources)
+  \- Read-only data resources
 - [Workflow Examples](./examples.md) - Complete workflow walkthroughs
 - [MCP Prompts Specification](https://modelcontextprotocol.io/docs/concepts/prompts) -
   Official MCP documentation

--- a/docs/mcp-server/safety-patterns.md
+++ b/docs/mcp-server/safety-patterns.md
@@ -274,13 +274,13 @@ Required test cases for each elicitation tool:
 All HIGH-RISK deletion operations now require user confirmation:
 
 - ✅ `delete_product` -
-  [products.py:214-296](../stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/products.py)
+  [products.py:214-296](https://github.com/dougborg/stocktrim-openapi-client/blob/main/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/products.py)
 - ✅ `delete_supplier` -
-  [suppliers.py:204-289](../stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py)
+  [suppliers.py:204-289](https://github.com/dougborg/stocktrim-openapi-client/blob/main/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py)
 - ✅ `delete_purchase_order` -
-  [purchase_orders.py:370-464](../stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/purchase_orders.py)
+  [purchase_orders.py:370-464](https://github.com/dougborg/stocktrim-openapi-client/blob/main/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/purchase_orders.py)
 - ✅ `delete_sales_orders` -
-  [sales_orders.py:290-404](../stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/sales_orders.py)
+  [sales_orders.py:290-404](https://github.com/dougborg/stocktrim-openapi-client/blob/main/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/sales_orders.py)
 
 Test coverage: 20 tests added (5 per tool)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "pytest-mock>=3.15.1",
     "pytest-timeout>=2.4.0",
+    "stocktrim-mcp-server",
     "ty>=0.0.1a24",
 ]
 
@@ -132,6 +133,9 @@ dev = [
 
 [tool.uv.workspace]
 members = [".", "stocktrim_mcp_server"]
+
+[tool.uv.sources]
+stocktrim-mcp-server = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["stocktrim_public_api_client"]

--- a/stocktrim_public_api_client/helpers/customers.py
+++ b/stocktrim_public_api_client/helpers/customers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 from stocktrim_public_api_client.generated.api.customers import (
     get_api_customers,
@@ -96,7 +96,7 @@ class Customers(Base):
         except Exception:
             return False
 
-    async def find_or_create(self, code: str, **defaults) -> CustomerDto:
+    async def find_or_create(self, code: str, **defaults: Any) -> CustomerDto:
         """Get customer by code, or create if doesn't exist.
 
         Args:

--- a/uv.lock
+++ b/uv.lock
@@ -2204,6 +2204,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
+    { name = "stocktrim-mcp-server" },
     { name = "ty" },
 ]
 
@@ -2257,6 +2258,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "stocktrim-mcp-server", editable = "stocktrim_mcp_server" },
     { name = "ty", specifier = ">=0.0.1a24" },
 ]
 


### PR DESCRIPTION
## Summary

Two small, independent housekeeping fixes bundled in one PR (one commit each).

### Commit 1 — `build: install stocktrim-mcp-server workspace member by default` (closes #172)

`uv sync` / `uv sync --all-extras` (the canonical setup commands documented in 9 places) did **not** install the `stocktrim-mcp-server` workspace member into the project venv, causing fresh contributors' `uv run poe test-mcp` to fail with `ModuleNotFoundError: No module named 'stocktrim_mcp_server.services'`. Fix:

```toml
[dependency-groups]
dev = [
    ...
    "stocktrim-mcp-server",
]

[tool.uv.sources]
stocktrim-mcp-server = { workspace = true }
```

With this, plain `uv sync` installs the MCP workspace member + dev-group tools (poethepoet, pytest stack, ty), and `uv sync --all-extras` adds the existing project extras (ruff, mdformat, etc.). No documentation updates needed.

### Commit 2 — `docs: clean up pre-existing mkdocs build warnings` (closes #173)

`uv run poe docs-build` had been emitting 7 warnings and 2 info diagnostics:

- 1× griffe: `Customers.find_or_create(**defaults)` lacked a type annotation → annotated as `**defaults: Any`.
- 5× broken in-tree links that pointed to source files outside the docs tree (`../README.md`, four `../stocktrim_mcp_server/src/...` paths) → repointed to absolute GitHub URLs.
- 1× typo in `examples.md` TOC anchor (`#workflow-5-custom-order-fulfillment` → `#workflow-5-customer-order-fulfillment`).
- 1× stale anchor `./overview.md#resources` in `prompts.md` → repointed to the upstream MCP resources spec, since `overview.md` has no `Resources` section.

After: `poe docs-build` finishes warning-free.

## Test plan

- [x] `rm -rf .venv && uv sync && python -c "import stocktrim_mcp_server.services.customers"` succeeds (bare `uv sync` now sufficient)
- [x] `uv sync --all-extras` brings in ruff, ty, MCP module — all green
- [x] `uv run poe check` — 75 client tests + 309 MCP tests pass
- [x] `uv run poe docs-build` — zero warnings
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)