### PR TITLE
fix: address Copilot review feedback on #168 and #170

### DIFF
--- a/stocktrim_public_api_client/stocktrim_client.py
+++ b/stocktrim_public_api_client/stocktrim_client.py
@@ -509,8 +509,8 @@ class AuthHeaderTransport(AsyncHTTPTransport):
 def create_resilient_transport(
     api_auth_signature: str,
     max_retries: int = 5,
-    total_retry_timeout: float | None = 60.0,
     logger: logging.Logger | None = None,
+    total_retry_timeout: float | None = 60.0,
     **kwargs: Any,
 ) -> tuple[RetryTransport, ErrorLoggingTransport]:
     """
@@ -529,12 +529,12 @@ def create_resilient_transport(
     Args:
         api_auth_signature: StockTrim API authentication signature
         max_retries: Maximum number of retry attempts for failed requests. Defaults to 5.
+        logger: Logger instance for capturing operations. If None, creates a default logger.
         total_retry_timeout: Cumulative cap (seconds) on sleep time across retry
             attempts for a single request. Stops further retries once exceeded,
             even if ``max_retries`` would allow more. Defaults to 60s, which
             comfortably covers full exponential backoff (1+2+4+8+16=31s) plus
             slack for ``Retry-After`` headers; set ``None`` to disable.
-        logger: Logger instance for capturing operations. If None, creates a default logger.
         **kwargs: Additional arguments passed to the base AsyncHTTPTransport.
             Common parameters include:
             - http2 (bool): Enable HTTP/2 support
@@ -656,8 +656,8 @@ class StockTrimClient(AuthenticatedClient):
         base_url: str | None = None,
         timeout: float = 30.0,
         max_retries: int = 5,
-        total_retry_timeout: float | None = 60.0,
         logger: logging.Logger | None = None,
+        total_retry_timeout: float | None = 60.0,
         **httpx_kwargs: Any,
     ):
         """
@@ -671,9 +671,9 @@ class StockTrimClient(AuthenticatedClient):
             base_url: Base URL for the StockTrim API. Defaults to https://api.stocktrim.com
             timeout: Request timeout in seconds. Defaults to 30.0.
             max_retries: Maximum number of retry attempts for failed requests. Defaults to 5.
+            logger: Logger instance for capturing client operations. If None, creates a default logger.
             total_retry_timeout: Cumulative cap (seconds) on sleep time across retry
                 attempts for a single request. Defaults to 60s; pass ``None`` to disable.
-            logger: Logger instance for capturing client operations. If None, creates a default logger.
             **httpx_kwargs: Additional arguments passed to the base AsyncHTTPTransport.
                 Common parameters include:
                 - http2 (bool): Enable HTTP/2 support

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,13 +214,3 @@ def mock_not_found_response():
     response.headers = {"Content-Type": "application/problem+json"}
     response.text = '{"type": "...", "title": "Not Found", "status": 404}'
     return response
-
-
-@pytest.fixture
-def stocktrim_client_with_mock_transport(mock_api_credentials, mock_transport):
-    """Create a StockTrimClient with mock transport for testing without network calls."""
-    client = StockTrimClient(**mock_api_credentials)
-    # Replace the transport with mock
-    assert client._client is not None
-    client._client._transport = mock_transport
-    return client


### PR DESCRIPTION
## Summary

Cleans up two issues Copilot flagged on already-merged PRs that I shipped without waiting for review. Both verified empirically, two commits, one per finding.

### Commit 1 — `fix(client): preserve positional arg order for total_retry_timeout`

**Finding** ([Copilot on #170](https://github.com/dougborg/stocktrim-openapi-client/pull/170)):
> Adding `total_retry_timeout` between `max_retries` and `logger` changes the positional-argument order for this public factory. Any downstream code calling `create_resilient_transport(api_auth_signature, max_retries, logger)` positionally will now pass the logger as `total_retry_timeout` instead.

True and a real backward-compat hazard for `create_resilient_transport` and `StockTrimClient.__init__`. Moves `total_retry_timeout` to the end of the kwargs block (just before `**kwargs` / `**httpx_kwargs`), preserving the original positional layout from before #170. Default value (60s) and behavior unchanged.

### Commit 2 — `test: remove dead stocktrim_client_with_mock_transport fixture`

**Finding** ([Copilot on #168](https://github.com/dougborg/stocktrim-openapi-client/pull/168)):
> `AuthenticatedClient._client` is initialized to `None` and isn't created until `get_httpx_client()` (or entering the context manager) is called. As written, `assert client._client is not None` will fail whenever this fixture is used.

Verified — right after construction, `c._client is None`. My #168 "fix" had replaced a `# type: ignore[union-attr]` with an `assert client._client is not None`, but the assert would always blow up the moment the fixture was actually used. Why CI stayed green: `grep -rn stocktrim_client_with_mock_transport` finds **zero** callers. The fixture has been dead-on-arrival, masked first by mypy-style ignore and then by my "fix" of equal-but-different brokenness. Deleting it; nothing depends on it and the working tests use `httpx.MockTransport` via the existing `mock_transport_handler` fixture pattern.

## Test plan

- [x] `uv run poe check` — 75 client tests + 309 MCP tests pass
- [x] `grep -rn stocktrim_client_with_mock_transport tests/ stocktrim_mcp_server/tests/` returns no callers
- [x] Manual check: `StockTrimClient(...)._client` is `None` after construction (matches Copilot's claim)
- [ ] CI green on this PR
- [ ] Copilot review comments resolved on the PRs they were filed against

🤖 Generated with [Claude Code](https://claude.com/claude-code)