### PR TITLE
refactor(mcp): docstring clarity + factor delete elicitation helper

### DIFF
--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/elicitation.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/elicitation.py
@@ -1,0 +1,66 @@
+"""Shared MCP elicitation helpers for destructive tools."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from fastmcp import Context
+from fastmcp.server.elicitation import (
+    AcceptedElicitation,
+    CancelledElicitation,
+    DeclinedElicitation,
+)
+from pydantic import BaseModel
+
+R = TypeVar("R", bound=BaseModel)
+
+
+async def run_delete_elicitation(
+    context: Context,
+    *,
+    message: str,
+    entity_label: str,
+    on_accept: Callable[[], Awaitable[tuple[bool, str]]],
+    response_factory: Callable[[bool, str], R],
+) -> R:
+    """Run the standard MCP elicitation flow for a destructive delete tool.
+
+    Wraps the four-arm match block (Accepted / Declined / Cancelled / fallthrough)
+    that every ``_delete_*_impl`` repeats. ``on_accept`` performs the actual
+    deletion and must return a ``(success, message)`` tuple; the helper formats
+    the user-facing message and delegates response construction to
+    ``response_factory``, which preserves the concrete ``Delete*Response`` type
+    at the call site (so callers don't need a cast).
+
+    Args:
+        context: FastMCP request context used to issue the elicitation.
+        message: Preview text shown to the user before they confirm.
+        entity_label: User-facing label inserted into declined/cancelled/
+            unexpected messages (e.g. ``"supplier WH-01"`` or
+            ``"sales orders for product P123"``).
+        on_accept: Async callable invoked when the user accepts. Must return
+            ``(success, message)`` from the underlying service delete.
+        response_factory: Constructor for the concrete response model;
+            called with ``(success, formatted_message)``.
+
+    Returns:
+        The response model produced by ``response_factory``.
+    """
+    result = await context.elicit(message=message, response_type=None)
+    match result:
+        case AcceptedElicitation():
+            success, msg = await on_accept()
+            return response_factory(success, f"✅ {msg}" if success else msg)
+        case DeclinedElicitation():
+            return response_factory(
+                False, f"❌ Deletion of {entity_label} declined by user"
+            )
+        case CancelledElicitation():
+            return response_factory(
+                False, f"❌ Deletion of {entity_label} cancelled by user"
+            )
+        case _:
+            return response_factory(
+                False, f"Unexpected elicitation response for {entity_label}"
+            )

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/customers.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/customers.py
@@ -37,8 +37,8 @@ class CustomerInfo(BaseModel):
 
 
 class GetCustomerResponse(BaseModel):
-    """Response wrapper for ``get_customer`` so the ``None`` case still
-    serializes through ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result`` regardless of whether the inner field is None."""
 
     customer: CustomerInfo | None = None
 

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/locations.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/locations.py
@@ -84,8 +84,8 @@ class CreateLocationRequest(BaseModel):
 
 
 class CreateLocationResponse(BaseModel):
-    """Response wrapper so a single ``LocationInfo`` serializes through
-    ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result``."""
 
     location: LocationInfo
 

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/products.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/products.py
@@ -48,15 +48,15 @@ class ProductInfo(BaseModel):
 
 
 class GetProductResponse(BaseModel):
-    """Response wrapper so the ``None`` case still serializes through
-    ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result`` regardless of whether the inner field is None."""
 
     product: ProductInfo | None = None
 
 
 class CreateProductResponse(BaseModel):
-    """Response wrapper so a single ``ProductInfo`` serializes through
-    ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result``."""
 
     product: ProductInfo
 

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/products.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/products.py
@@ -6,15 +6,11 @@ import logging
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.elicitation import (
-    AcceptedElicitation,
-    CancelledElicitation,
-    DeclinedElicitation,
-)
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
 
 from stocktrim_mcp_server.dependencies import get_services
+from stocktrim_mcp_server.tools.elicitation import run_delete_elicitation
 from stocktrim_mcp_server.tools.tool_result_utils import make_json_result
 from stocktrim_mcp_server.unpack import Unpack, unpack_pydantic_params
 from stocktrim_mcp_server.utils import unwrap_unset
@@ -273,7 +269,8 @@ async def _delete_product_impl(
     status_emoji = "🔴" if product.discontinued else "🟢"
     status_text = "Discontinued" if product.discontinued else "Active"
 
-    result = await context.elicit(
+    return await run_delete_elicitation(
+        context,
         message=f"""⚠️ Delete product {product_code}?
 
 {status_emoji} **{product_name}**
@@ -282,31 +279,12 @@ Status: {status_text}
 This action will permanently delete the product and cannot be undone.
 
 Proceed with deletion?""",
-        response_type=None,
+        entity_label=f"product {product_code}",
+        on_accept=lambda: services.products.delete(request.code),
+        response_factory=lambda success, message: DeleteProductResponse(
+            success=success, message=message
+        ),
     )
-
-    match result:
-        case AcceptedElicitation():
-            success, message = await services.products.delete(request.code)
-            return DeleteProductResponse(
-                success=success,
-                message=f"✅ {message}" if success else message,
-            )
-        case DeclinedElicitation():
-            return DeleteProductResponse(
-                success=False,
-                message=f"❌ Deletion of product {product_code} declined by user",
-            )
-        case CancelledElicitation():
-            return DeleteProductResponse(
-                success=False,
-                message=f"❌ Deletion of product {product_code} cancelled by user",
-            )
-        case _:
-            return DeleteProductResponse(
-                success=False,
-                message=f"Unexpected elicitation response for product {product_code}",
-            )
 
 
 @unpack_pydantic_params

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/purchase_orders.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/purchase_orders.py
@@ -44,8 +44,8 @@ class PurchaseOrderInfo(BaseModel):
 
 
 class GetPurchaseOrderResponse(BaseModel):
-    """Response wrapper so the ``None`` case still serializes through
-    ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result`` regardless of whether the inner field is None."""
 
     purchase_order: PurchaseOrderInfo | None = None
 

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/purchase_orders.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/purchase_orders.py
@@ -7,15 +7,11 @@ from datetime import datetime
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.elicitation import (
-    AcceptedElicitation,
-    CancelledElicitation,
-    DeclinedElicitation,
-)
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
 
 from stocktrim_mcp_server.dependencies import get_services
+from stocktrim_mcp_server.tools.elicitation import run_delete_elicitation
 from stocktrim_mcp_server.tools.tool_result_utils import make_json_result
 from stocktrim_mcp_server.unpack import Unpack, unpack_pydantic_params
 
@@ -389,7 +385,8 @@ async def _delete_purchase_order_impl(
     )
     status_info = po_info.status or "Unknown"
 
-    result = await context.elicit(
+    return await run_delete_elicitation(
+        context,
         message=f"""⚠️ Delete purchase order {po_info.reference_number}?
 
 **Supplier**: {supplier_info}
@@ -400,33 +397,12 @@ async def _delete_purchase_order_impl(
 This action will permanently delete the purchase order and cannot be undone.
 
 Proceed with deletion?""",
-        response_type=None,
+        entity_label=f"purchase order {po_info.reference_number}",
+        on_accept=lambda: services.purchase_orders.delete(request.reference_number),
+        response_factory=lambda success, message: DeletePurchaseOrderResponse(
+            success=success, message=message
+        ),
     )
-
-    match result:
-        case AcceptedElicitation():
-            success, message = await services.purchase_orders.delete(
-                request.reference_number
-            )
-            return DeletePurchaseOrderResponse(
-                success=success,
-                message=f"✅ {message}" if success else message,
-            )
-        case DeclinedElicitation():
-            return DeletePurchaseOrderResponse(
-                success=False,
-                message=f"❌ Deletion of purchase order {po_info.reference_number} declined by user",
-            )
-        case CancelledElicitation():
-            return DeletePurchaseOrderResponse(
-                success=False,
-                message=f"❌ Deletion of purchase order {po_info.reference_number} cancelled by user",
-            )
-        case _:
-            return DeletePurchaseOrderResponse(
-                success=False,
-                message=f"Unexpected elicitation response for purchase order {po_info.reference_number}",
-            )
 
 
 @unpack_pydantic_params

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/sales_orders.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/sales_orders.py
@@ -7,15 +7,11 @@ from datetime import datetime
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.elicitation import (
-    AcceptedElicitation,
-    CancelledElicitation,
-    DeclinedElicitation,
-)
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
 
 from stocktrim_mcp_server.dependencies import get_services
+from stocktrim_mcp_server.tools.elicitation import run_delete_elicitation
 from stocktrim_mcp_server.tools.tool_result_utils import make_json_result
 from stocktrim_mcp_server.unpack import Unpack, unpack_pydantic_params
 from stocktrim_mcp_server.utils import unwrap_unset
@@ -321,7 +317,8 @@ async def _delete_sales_orders_impl(
     )
     revenue_info = f"${total_revenue:,.2f}" if total_revenue > 0 else "Unknown"
 
-    result = await context.elicit(
+    return await run_delete_elicitation(
+        context,
         message=f"""⚠️ Delete {order_count} sales order{"s" if order_count != 1 else ""} for product {request.product_id}?
 
 **Orders to Delete**: {order_count}
@@ -332,33 +329,12 @@ async def _delete_sales_orders_impl(
 This action will permanently delete all sales orders for this product and cannot be undone.
 
 Proceed with deletion?""",
-        response_type=None,
+        entity_label=f"sales orders for product {request.product_id}",
+        on_accept=lambda: services.sales_orders.delete_for_product(request.product_id),
+        response_factory=lambda success, message: DeleteSalesOrdersResponse(
+            success=success, message=message
+        ),
     )
-
-    match result:
-        case AcceptedElicitation():
-            success, message = await services.sales_orders.delete_for_product(
-                request.product_id
-            )
-            return DeleteSalesOrdersResponse(
-                success=success,
-                message=f"✅ {message}" if success else message,
-            )
-        case DeclinedElicitation():
-            return DeleteSalesOrdersResponse(
-                success=False,
-                message=f"❌ Deletion of sales orders for product {request.product_id} declined by user",
-            )
-        case CancelledElicitation():
-            return DeleteSalesOrdersResponse(
-                success=False,
-                message=f"❌ Deletion of sales orders for product {request.product_id} cancelled by user",
-            )
-        case _:
-            return DeleteSalesOrdersResponse(
-                success=False,
-                message="Unexpected elicitation response for sales orders deletion",
-            )
 
 
 @unpack_pydantic_params

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/sales_orders.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/sales_orders.py
@@ -60,8 +60,8 @@ class SalesOrderInfo(BaseModel):
 
 
 class CreateSalesOrderResponse(BaseModel):
-    """Response wrapper so a single ``SalesOrderInfo`` serializes through
-    ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result``."""
 
     sales_order: SalesOrderInfo
 

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.elicitation import (
-    AcceptedElicitation,
-    CancelledElicitation,
-    DeclinedElicitation,
-)
 from fastmcp.tools import ToolResult
 from pydantic import BaseModel, Field
 
 from stocktrim_mcp_server.dependencies import get_services
 from stocktrim_mcp_server.logging_config import get_logger
+from stocktrim_mcp_server.tools.elicitation import run_delete_elicitation
 from stocktrim_mcp_server.tools.tool_result_utils import make_json_result
 from stocktrim_mcp_server.unpack import Unpack, unpack_pydantic_params
 
@@ -232,7 +228,8 @@ async def _delete_supplier_impl(
         supplier.primary_contact_name or supplier.email_address or "No contact"
     )
 
-    result = await context.elicit(
+    return await run_delete_elicitation(
+        context,
         message=f"""⚠️ Delete supplier {supplier_code}?
 
 **{supplier_name}**
@@ -242,31 +239,12 @@ This action will permanently delete the supplier and all associations (product m
 This cannot be undone.
 
 Proceed with deletion?""",
-        response_type=None,
+        entity_label=f"supplier {supplier_code}",
+        on_accept=lambda: services.suppliers.delete(request.code),
+        response_factory=lambda success, message: DeleteSupplierResponse(
+            success=success, message=message
+        ),
     )
-
-    match result:
-        case AcceptedElicitation():
-            success, message = await services.suppliers.delete(request.code)
-            return DeleteSupplierResponse(
-                success=success,
-                message=f"✅ {message}" if success else message,
-            )
-        case DeclinedElicitation():
-            return DeleteSupplierResponse(
-                success=False,
-                message=f"❌ Deletion of supplier {supplier_code} declined by user",
-            )
-        case CancelledElicitation():
-            return DeleteSupplierResponse(
-                success=False,
-                message=f"❌ Deletion of supplier {supplier_code} cancelled by user",
-            )
-        case _:
-            return DeleteSupplierResponse(
-                success=False,
-                message=f"Unexpected elicitation response for supplier {supplier_code}",
-            )
 
 
 @unpack_pydantic_params

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py
@@ -41,15 +41,15 @@ class SupplierInfo(BaseModel):
 
 
 class GetSupplierResponse(BaseModel):
-    """Response wrapper so the ``None`` case still serializes through
-    ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result`` regardless of whether the inner field is None."""
 
     supplier: SupplierInfo | None = None
 
 
 class CreateSupplierResponse(BaseModel):
-    """Response wrapper so a single ``SupplierInfo`` serializes through
-    ``make_json_result``."""
+    """Response wrapper so the typed payload round-trips through
+    ``unwrap_tool_result``."""
 
     supplier: SupplierInfo
 

--- a/stocktrim_mcp_server/tests/test_tools/test_elicitation.py
+++ b/stocktrim_mcp_server/tests/test_tools/test_elicitation.py
@@ -1,0 +1,137 @@
+"""Tests for the shared delete-tool elicitation helper."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.server.elicitation import (
+    AcceptedElicitation,
+    CancelledElicitation,
+    DeclinedElicitation,
+)
+from pydantic import BaseModel
+
+from stocktrim_mcp_server.tools.elicitation import run_delete_elicitation
+
+
+class _FakeDeleteResponse(BaseModel):
+    success: bool
+    message: str
+
+
+def _make_helpers():
+    """Build a (response_factory, on_accept) pair tracking the args passed in."""
+    on_accept = AsyncMock(return_value=(True, "deleted ok"))
+
+    def factory(success: bool, message: str) -> _FakeDeleteResponse:
+        return _FakeDeleteResponse(success=success, message=message)
+
+    return factory, on_accept
+
+
+@pytest.mark.asyncio
+async def test_accepted_success_prefixes_checkmark():
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=None))
+    factory, on_accept = _make_helpers()
+    on_accept.return_value = (True, "supplier removed")
+
+    result = await run_delete_elicitation(
+        ctx,
+        message="preview",
+        entity_label="supplier WH-01",
+        on_accept=on_accept,
+        response_factory=factory,
+    )
+
+    assert isinstance(result, _FakeDeleteResponse)
+    assert result.success is True
+    assert result.message == "✅ supplier removed"
+    on_accept.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_accepted_failure_preserves_raw_message():
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=None))
+    factory, on_accept = _make_helpers()
+    on_accept.return_value = (False, "API rejected delete")
+
+    result = await run_delete_elicitation(
+        ctx,
+        message="preview",
+        entity_label="supplier WH-01",
+        on_accept=on_accept,
+        response_factory=factory,
+    )
+
+    assert result.success is False
+    assert result.message == "API rejected delete"
+
+
+@pytest.mark.asyncio
+async def test_declined_skips_on_accept_and_includes_entity_label():
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=DeclinedElicitation(data=None))
+    factory, on_accept = _make_helpers()
+
+    result = await run_delete_elicitation(
+        ctx,
+        message="preview",
+        entity_label="supplier WH-01",
+        on_accept=on_accept,
+        response_factory=factory,
+    )
+
+    assert result.success is False
+    assert result.message == "❌ Deletion of supplier WH-01 declined by user"
+    on_accept.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_skips_on_accept_and_includes_entity_label():
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=CancelledElicitation(data=None))
+    factory, on_accept = _make_helpers()
+
+    result = await run_delete_elicitation(
+        ctx,
+        message="preview",
+        entity_label="purchase order PO-42",
+        on_accept=on_accept,
+        response_factory=factory,
+    )
+
+    assert result.success is False
+    assert result.message == "❌ Deletion of purchase order PO-42 cancelled by user"
+    on_accept.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_response_falls_through_to_safety_branch():
+    """Critical: any non-Accepted/Declined/Cancelled response must land in
+    the safety branch (success=False), not silently invoke on_accept.
+
+    Guards a destructive code path against unexpected fastmcp response types.
+    """
+
+    class UnknownResponse:
+        pass
+
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=UnknownResponse())
+    factory, on_accept = _make_helpers()
+
+    result = await run_delete_elicitation(
+        ctx,
+        message="preview",
+        entity_label="sales orders for product X",
+        on_accept=on_accept,
+        response_factory=factory,
+    )
+
+    assert result.success is False
+    assert (
+        result.message
+        == "Unexpected elicitation response for sales orders for product X"
+    )
+    on_accept.assert_not_awaited()


### PR DESCRIPTION
Bundles two small follow-ups from the PR #188 post-merge review.

## Commit 1 — `docs(mcp)`: clarify wrapper response model docstrings (#190)

Eight one-field wrapper response models (`GetCustomerResponse`, `GetProductResponse`, `CreateLocationResponse`, etc.) had docstrings claiming "the None case still serializes through `make_json_result`" — imprecise. `make_json_result` handles None fine; the actual reason for the wrapper is that callers need a concrete model class to validate against when round-tripping through `unwrap_tool_result`.

Pure rewording, ~16 lines.

## Commit 2 — `refactor(mcp)`: factor delete-tool elicitation match into shared helper (#191)

The four `_delete_*_impl` tools (suppliers, products, purchase_orders, sales_orders) repeated the same four-arm Accepted/Declined/Cancelled/fallthrough match block. Extracted to `stocktrim_mcp_server.tools.elicitation.run_delete_elicitation`, generic over `R: BaseModel` so the concrete `Delete*Response` type is preserved at the call site (no cast).

**Before** (per tool, ~30 LOC):

```python
result = await context.elicit(message=preview, response_type=None)
match result:
    case AcceptedElicitation():
        success, message = await services.X.delete(...)
        return DeleteXResponse(success=success, message=f"✅ {message}" if success else message)
    case DeclinedElicitation():
        return DeleteXResponse(success=False, message=f"❌ Deletion of {label} declined by user")
    case CancelledElicitation():
        return DeleteXResponse(success=False, message=f"❌ Deletion of {label} cancelled by user")
    case _:
        return DeleteXResponse(success=False, message=f"Unexpected elicitation response for {label}")
```

**After** (per tool, ~10 LOC):

```python
return await run_delete_elicitation(
    context,
    message=preview,
    entity_label=f"supplier {supplier_code}",
    on_accept=lambda: services.suppliers.delete(request.code),
    response_factory=lambda success, message: DeleteSupplierResponse(
        success=success, message=message
    ),
)
```

Net **-92 LOC** across 4 tools while consolidating the security-sensitive flow into one auditable place.

The `sales_orders` "Unexpected elicitation response" message now follows the same template as the other three (was previously `"for sales orders deletion"`, now `"for sales orders for product {id}"`) — slightly more informative; no test pinned the prior wording.

Closes #190.
Closes #191.

## Test plan

- [x] `uv run poe check` passes — ruff format, mdformat, ruff lint, ty type-check, yamllint
- [x] All 83 client lib tests pass
- [x] All 321 MCP server tests pass (covers Accepted, Declined, Cancelled branches for all 4 delete tools)
- [ ] Wait for Copilot review and CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)