### PR TITLE
fix: handle three StockTrim API quirks surfaced via MCP audit

### DIFF
--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -186,6 +186,9 @@ def add_nullable_to_date_fields(spec_path: Path) -> bool:
             "PurchaseOrderLineItem": [
                 "receivedDate",  # date-time ⚠️ CRITICAL - crashes when null
             ],
+            "SupplierResponseDto": [
+                "supplierCode",  # string - API returns null for orphaned suppliers
+            ],
         }
 
         schemas = spec.get("components", {}).get("schemas", {})

--- a/stocktrim-openapi.yaml
+++ b/stocktrim-openapi.yaml
@@ -2438,8 +2438,6 @@ components:
           nullable: true
       additionalProperties: false
     SupplierResponseDto:
-      required:
-      - supplierCode
       type: object
       properties:
         id:
@@ -2448,6 +2446,7 @@ components:
         supplierCode:
           minLength: 1
           type: string
+          nullable: true
         supplierName:
           type: string
           nullable: true

--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/foundation/suppliers.py
@@ -30,7 +30,7 @@ class GetSupplierRequest(BaseModel):
 class SupplierInfo(BaseModel):
     """Supplier information."""
 
-    code: str
+    code: str | None
     name: str | None
     email: str | None
     primary_contact: str | None

--- a/stocktrim_mcp_server/tests/test_tools/test_foundation/test_suppliers.py
+++ b/stocktrim_mcp_server/tests/test_tools/test_foundation/test_suppliers.py
@@ -192,6 +192,26 @@ async def test_list_suppliers_empty(mock_supplier_context):
     assert len(response.suppliers) == 0
 
 
+@pytest.mark.asyncio
+async def test_list_suppliers_handles_null_supplier_code(mock_supplier_context):
+    """API has been observed returning suppliers with supplier_code=None;
+    SupplierInfo.code must accept None instead of raising a validation error."""
+    services = mock_supplier_context.request_context.lifespan_context
+    orphaned = SupplierResponseDto(
+        supplier_code=None,
+        supplier_name="Legacy Supplier",
+        email_address=None,
+        primary_contact_name=None,
+    )
+    services.suppliers.list_all.return_value = [orphaned]
+
+    response = await _call_list(active_only=True, context=mock_supplier_context)
+
+    assert response.total_count == 1
+    assert response.suppliers[0].code is None
+    assert response.suppliers[0].name == "Legacy Supplier"
+
+
 # ============================================================================
 # Test create_supplier
 # ============================================================================

--- a/stocktrim_public_api_client/generated/models/supplier_response_dto.py
+++ b/stocktrim_public_api_client/generated/models/supplier_response_dto.py
@@ -14,8 +14,8 @@ T = TypeVar("T", bound="SupplierResponseDto")
 class SupplierResponseDto:
     """
     Attributes:
-        supplier_code (str):
         id (int | Unset):
+        supplier_code (None | str | Unset):
         supplier_name (None | str | Unset):
         email_address (None | str | Unset):
         primary_contact_name (None | str | Unset):
@@ -29,8 +29,8 @@ class SupplierResponseDto:
         post_code (None | str | Unset):
     """
 
-    supplier_code: str
     id: int | Unset = UNSET
+    supplier_code: None | str | Unset = UNSET
     supplier_name: None | str | Unset = UNSET
     email_address: None | str | Unset = UNSET
     primary_contact_name: None | str | Unset = UNSET
@@ -44,9 +44,13 @@ class SupplierResponseDto:
     post_code: None | str | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
-        supplier_code = self.supplier_code
-
         id = self.id
+
+        supplier_code: None | str | Unset
+        if isinstance(self.supplier_code, Unset):
+            supplier_code = UNSET
+        else:
+            supplier_code = self.supplier_code
 
         supplier_name: None | str | Unset
         if isinstance(self.supplier_name, Unset):
@@ -116,13 +120,11 @@ class SupplierResponseDto:
 
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "supplierCode": supplier_code,
-            }
-        )
+        field_dict.update({})
         if id is not UNSET:
             field_dict["id"] = id
+        if supplier_code is not UNSET:
+            field_dict["supplierCode"] = supplier_code
         if supplier_name is not UNSET:
             field_dict["supplierName"] = supplier_name
         if email_address is not UNSET:
@@ -151,9 +153,16 @@ class SupplierResponseDto:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        supplier_code = d.pop("supplierCode")
-
         id = d.pop("id", UNSET)
+
+        def _parse_supplier_code(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        supplier_code = _parse_supplier_code(d.pop("supplierCode", UNSET))
 
         def _parse_supplier_name(data: object) -> None | str | Unset:
             if data is None:
@@ -257,8 +266,8 @@ class SupplierResponseDto:
         post_code = _parse_post_code(d.pop("postCode", UNSET))
 
         supplier_response_dto = cls(
-            supplier_code=supplier_code,
             id=id,
+            supplier_code=supplier_code,
             supplier_name=supplier_name,
             email_address=email_address,
             primary_contact_name=primary_contact_name,

--- a/stocktrim_public_api_client/helpers/purchase_orders.py
+++ b/stocktrim_public_api_client/helpers/purchase_orders.py
@@ -50,6 +50,11 @@ class PurchaseOrders(Base):
             client=self._client,
             reference_number=reference_number,
         )
+        # StockTrim returns 404 instead of 200-with-empty-array when there are
+        # no purchase orders (or no PO matches the reference_number filter).
+        # See helpers/products.py for the same non-standard behavior.
+        if response.status_code == 404:
+            return []
         return cast(
             PurchaseOrderResponseDto | list[PurchaseOrderResponseDto],
             unwrap(response),

--- a/stocktrim_public_api_client/utils.py
+++ b/stocktrim_public_api_client/utils.py
@@ -121,15 +121,7 @@ def unwrap(
             products = unwrap(response)  # Raises on error, returns parsed data
         ```
     """
-    if response.parsed is None:
-        if raise_on_error:
-            raise APIError(
-                f"No parsed response data for status {response.status_code}",
-                response.status_code,
-            )
-        return None
-
-    # Check if it's a ProblemDetails error response
+    # Identify ProblemDetails (if the body parsed into one) for richer messages
     problem_details = None
     try:
         from .generated.models.problem_details import ProblemDetails
@@ -139,7 +131,10 @@ def unwrap(
     except ImportError:
         pass
 
-    # Handle error status codes
+    # Handle error status codes first — even when the body did not parse
+    # (e.g. StockTrim returns 500 with an HTML stack trace that the OpenAPI
+    # client cannot decode). Without this branch every 5xx without a parseable
+    # body would surface as the misleading "No parsed response data" APIError.
     if response.status_code >= 400:
         if not raise_on_error:
             return None
@@ -172,6 +167,15 @@ def unwrap(
             raise ServerError(message, response.status_code, problem_details)
         else:
             raise APIError(message, response.status_code, problem_details)
+
+    # Successful status but no parsed body — likely a generator gap
+    if response.parsed is None:
+        if raise_on_error:
+            raise APIError(
+                f"No parsed response data for status {response.status_code}",
+                response.status_code,
+            )
+        return None
 
     return response.parsed
 

--- a/tests/test_helpers_purchase_orders.py
+++ b/tests/test_helpers_purchase_orders.py
@@ -1,0 +1,48 @@
+"""Tests for the PurchaseOrders helper class."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from stocktrim_public_api_client.helpers.purchase_orders import PurchaseOrders
+
+
+@pytest.mark.asyncio
+async def test_get_all_returns_empty_list_on_404(monkeypatch):
+    """StockTrim returns 404 (not 200-with-empty-array) when there are no
+    purchase orders. The helper must translate this to an empty list."""
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.parsed = None
+
+    async_mock = AsyncMock(return_value=mock_response)
+
+    import stocktrim_public_api_client.generated.api.purchase_orders.get_api_purchase_orders as get_module
+
+    monkeypatch.setattr(get_module, "asyncio_detailed", async_mock)
+
+    purchase_orders = PurchaseOrders(Mock())
+    result = await purchase_orders.get_all()
+
+    assert result == []
+    async_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_find_by_reference_returns_none_on_404(monkeypatch):
+    """When filtering by reference number returns 404, find_by_reference
+    should yield None (via the empty-list translation in get_all)."""
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.parsed = None
+
+    async_mock = AsyncMock(return_value=mock_response)
+
+    import stocktrim_public_api_client.generated.api.purchase_orders.get_api_purchase_orders as get_module
+
+    monkeypatch.setattr(get_module, "asyncio_detailed", async_mock)
+
+    purchase_orders = PurchaseOrders(Mock())
+    result = await purchase_orders.find_by_reference("MISSING-PO")
+
+    assert result is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,6 +168,42 @@ class TestUnwrap:
             AuthenticationError | PermissionError | NotFoundError | ValidationError,
         )
 
+    def test_unwrap_500_with_unparseable_body_raises_server_error(self):
+        """A 5xx response whose body did not parse (parsed=None) must still
+        raise ServerError, not the misleading 'No parsed response data' APIError.
+
+        Regression: StockTrim's Order Plan endpoint occasionally returns 500
+        with an HTML stack-trace body the OpenAPI client cannot decode."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=b"<html>...</html>",
+            headers={},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        assert exc_info.value.status_code == 500
+        assert "No parsed response data" not in str(exc_info.value)
+
+    def test_unwrap_404_with_unparseable_body_raises_not_found_error(self):
+        """A 404 with parsed=None should raise NotFoundError, not generic APIError."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.NOT_FOUND, content=b"", headers={}, parsed=None
+        )
+        with pytest.raises(NotFoundError) as exc_info:
+            unwrap(response)
+        assert exc_info.value.status_code == 404
+
+    def test_unwrap_2xx_with_no_parsed_body_raises_generic_api_error(self):
+        """A 2xx with no parsed body still hits the original APIError path
+        (this is the only legitimate use of 'No parsed response data')."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.OK, content=b"", headers={}, parsed=None
+        )
+        with pytest.raises(APIError) as exc_info:
+            unwrap(response)
+        assert "No parsed response data" in str(exc_info.value)
+
 
 class TestIsSuccess:
     """Test the is_success function."""


### PR DESCRIPTION
## Summary

Three concrete tool failures from a Claude Desktop audit on 2026-05-26 (session `local_08682e5e-9a5c-4233-a3d4-cbec7cbabe9d`):

| # | Tool | Args | Error | Fix |
|---|------|------|-------|-----|
| 1 | `list_purchase_orders` | `{}` | `No parsed response data for status 404` | `helpers/purchase_orders.py` now translates 404 → `[]`, matching the existing `products.get_all` pattern. |
| 2 | `list_suppliers` | `{"active_only": true}` | `SupplierInfo.code: Input None` | `supplierCode` added to `NULLABLE_FIELDS`, model regenerated, MCP wrapper relaxed to `str \| None`. |
| 3 | `search_products` | `{"search_query": "SRAM"}` | `No parsed response data for status 500` | `utils.unwrap()` reordered so 4xx/5xx raise their specific exception (`ServerError`, `NotFoundError`, etc.) even when the body cannot be decoded. Previously the "no parsed body" branch fired first and swallowed the status. |

## Test plan

- [x] `uv run poe check` passes (208 files formatted, ruff/ty/yamllint clean)
- [x] All 89 client-library tests pass
- [x] All 327 MCP-server tests pass
- [x] New regression tests:
  - `tests/test_helpers_purchase_orders.py` (404 → empty list)
  - `tests/test_utils.py` (3 cases for `parsed=None` + error status)
  - `stocktrim_mcp_server/tests/.../test_suppliers.py` (null `supplierCode`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)