### PR TITLE
fix(mcp): surface upstream body on 5xx; unbreak review_urgent_order_requirements 415

### DIFF
--- a/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/workflows/urgent_orders.py
+++ b/stocktrim_mcp_server/src/stocktrim_mcp_server/tools/workflows/urgent_orders.py
@@ -17,12 +17,44 @@ from stocktrim_mcp_server.logging_config import get_logger
 from stocktrim_mcp_server.tools.preferences import load_preferences, resolve
 from stocktrim_mcp_server.tools.tool_result_utils import make_json_result
 from stocktrim_mcp_server.utils import unwrap_unset
-from stocktrim_public_api_client.client_types import UNSET
+from stocktrim_public_api_client.client_types import UNSET, Unset
+from stocktrim_public_api_client.generated.models.order_plan_filter_criteria import (
+    OrderPlanFilterCriteria,
+)
 from stocktrim_public_api_client.generated.models.order_plan_filter_criteria_dto import (
     OrderPlanFilterCriteriaDto,
 )
 
 logger = get_logger(__name__)
+
+
+_NARROWED_LOG_PREVIEW = 5
+
+
+def _first_or_unset(values: list[str] | None, field_name: str) -> str | Unset:
+    """Narrow a list-shaped MCP request field down to a single API-side filter.
+
+    StockTrim's /api/OrderPlan accepts only one location/supplier per call,
+    but the MCP request schema takes lists for forward compatibility. When
+    the caller supplies multiple values we keep the first and log a warning
+    so the call still succeeds (instead of 415-ing) and operators see that
+    further narrowing happened. The warning payload only includes a
+    bounded preview of the dropped values to keep structured logs small
+    when callers pass long lists.
+    """
+    if not values:
+        return UNSET
+    if len(values) > 1:
+        dropped = values[1:]
+        logger.warning(
+            "order_plan_multifilter_narrowed",
+            field=field_name,
+            kept=values[0],
+            dropped_count=len(dropped),
+            dropped_preview=dropped[:_NARROWED_LOG_PREVIEW],
+        )
+    return values[0]
+
 
 # ============================================================================
 # Tool 1: review_urgent_order_requirements
@@ -100,6 +132,7 @@ async def _review_urgent_order_requirements_impl(
     """
     prefs = await load_preferences(context)
     days_threshold = resolve(request.days_threshold, prefs, "days_threshold", 30)
+    category = resolve(request.category, prefs, "category", None)
     # Use `is None` (not truthiness) so an explicit empty list from the caller
     # clears the filter for this call instead of silently falling back to the
     # stored preference. Same pattern below for supplier_codes.
@@ -122,12 +155,22 @@ async def _review_urgent_order_requirements_impl(
         # Get services from context (note: order_plan not in service layer yet, uses client directly)
         services = get_services(context)
 
-        # Build filter criteria for order plan query
-        # Note: order_plan.get_urgent_items() doesn't support all our filters,
-        # so we'll query with filters and filter by days threshold ourselves
-        filter_criteria = OrderPlanFilterCriteriaDto(
-            location_codes=location_codes or UNSET,
-            supplier_codes=supplier_codes or UNSET,
+        # The /api/OrderPlan endpoint expects an OrderPlanFilterCriteria
+        # (singular `location`/`supplier`/`category`), not the list-shaped
+        # OrderPlanFilterCriteriaDto used by the V2 PO generation endpoint.
+        # Passing the Dto here made StockTrim reject the body with 415
+        # (bug surfaced 2026-05-26). The API only supports one location/one
+        # supplier per call; the lists produced by the session-preference
+        # fallback above are narrowed to the first element here (logged as
+        # a warning) so the call no longer fails when callers supply more
+        # than one value.
+        location = _first_or_unset(location_codes, "location_codes")
+        supplier = _first_or_unset(supplier_codes, "supplier_codes")
+
+        filter_criteria = OrderPlanFilterCriteria(
+            location=location,
+            supplier=supplier,
+            category=category or UNSET,
         )
 
         # Query order plan (uses client directly as order_plan not in service layer)

--- a/stocktrim_mcp_server/tests/test_tools/test_workflows/test_urgent_orders.py
+++ b/stocktrim_mcp_server/tests/test_tools/test_workflows/test_urgent_orders.py
@@ -204,6 +204,116 @@ async def test_review_urgent_orders_with_cost_calculation(
 
 
 @pytest.mark.asyncio
+async def test_review_urgent_orders_sends_singular_filter_criteria(
+    mock_urgent_context, urgent_order_item
+):
+    """The /api/OrderPlan endpoint expects OrderPlanFilterCriteria (singular
+    `location`/`supplier`/`category`), not OrderPlanFilterCriteriaDto. Sending
+    the Dto returns 415 from StockTrim (bug surfaced 2026-05-26).
+    """
+    from stocktrim_public_api_client.generated.models.order_plan_filter_criteria import (
+        OrderPlanFilterCriteria,
+    )
+
+    mock_client = mock_urgent_context.request_context.lifespan_context.client
+    mock_client.order_plan.query.return_value = [urgent_order_item]
+
+    request = ReviewUrgentOrdersRequest(
+        days_threshold=30,
+        location_codes=["WH-01"],
+        supplier_codes=["SUP-001"],
+        category="Widgets",
+    )
+    await _review(request, mock_urgent_context)
+
+    mock_client.order_plan.query.assert_called_once()
+    criteria = mock_client.order_plan.query.call_args.args[0]
+    assert isinstance(criteria, OrderPlanFilterCriteria)
+    # Singular fields mapped from the list-shaped request:
+    assert criteria.location == "WH-01"
+    assert criteria.supplier == "SUP-001"
+    assert criteria.category == "Widgets"
+
+
+@pytest.mark.asyncio
+async def test_review_urgent_orders_narrows_multifilter_with_warning(
+    mock_urgent_context, urgent_order_item
+):
+    """When multiple locations/suppliers are requested, only the first is
+    sent to the API (which doesn't support multi-filter) and a warning is
+    logged so operators see that the others were dropped."""
+    import structlog.testing
+
+    mock_client = mock_urgent_context.request_context.lifespan_context.client
+    mock_client.order_plan.query.return_value = [urgent_order_item]
+
+    request = ReviewUrgentOrdersRequest(
+        days_threshold=30,
+        location_codes=["WH-01", "WH-02"],
+        supplier_codes=["SUP-001", "SUP-002", "SUP-003"],
+    )
+    with structlog.testing.capture_logs() as captured:
+        await _review(request, mock_urgent_context)
+
+    criteria = mock_client.order_plan.query.call_args.args[0]
+    assert criteria.location == "WH-01"
+    assert criteria.supplier == "SUP-001"
+    # Both narrowings should have surfaced as warnings.
+    warnings = [
+        r
+        for r in captured
+        if r.get("log_level") == "warning"
+        and r.get("event") == "order_plan_multifilter_narrowed"
+    ]
+    by_field = {r["field"]: r for r in warnings}
+    assert set(by_field) == {"location_codes", "supplier_codes"}
+    # Counts and bounded previews replace the raw `dropped` list to keep
+    # structured logs small when callers pass long filter lists.
+    assert by_field["location_codes"]["dropped_count"] == 1
+    assert by_field["location_codes"]["dropped_preview"] == ["WH-02"]
+    assert by_field["supplier_codes"]["dropped_count"] == 2
+    assert by_field["supplier_codes"]["dropped_preview"] == ["SUP-002", "SUP-003"]
+
+
+@pytest.mark.asyncio
+async def test_review_urgent_orders_caps_warning_preview_for_long_lists(
+    mock_urgent_context, urgent_order_item
+):
+    """A very long list should still narrow to one value, but the warning
+    log only carries a bounded preview (not the full dropped list) so
+    structured logs don't bloat for outlier inputs."""
+    import structlog.testing
+
+    from stocktrim_mcp_server.tools.workflows.urgent_orders import (
+        _NARROWED_LOG_PREVIEW,
+    )
+
+    mock_client = mock_urgent_context.request_context.lifespan_context.client
+    mock_client.order_plan.query.return_value = [urgent_order_item]
+
+    long_locations = [f"WH-{i:03d}" for i in range(50)]
+    request = ReviewUrgentOrdersRequest(
+        days_threshold=30, location_codes=long_locations
+    )
+    with structlog.testing.capture_logs() as captured:
+        await _review(request, mock_urgent_context)
+
+    warning = next(
+        r
+        for r in captured
+        if r.get("event") == "order_plan_multifilter_narrowed"
+        and r.get("field") == "location_codes"
+    )
+    # 50 inputs → first kept, remaining 49 dropped; preview must be exactly
+    # the impl's cap (not a looser bound — looser would silently regress).
+    assert warning["dropped_count"] == 49
+    assert len(warning["dropped_preview"]) == _NARROWED_LOG_PREVIEW
+    # Preview starts at the right offset (first dropped element).
+    assert warning["dropped_preview"][0] == "WH-001"
+    assert warning["dropped_preview"][-1] == f"WH-{_NARROWED_LOG_PREVIEW:03d}"
+
+
+@pytest.mark.asyncio
 async def test_review_urgent_orders_filters_by_threshold(mock_urgent_context):
     """Test that items are filtered by days_threshold."""
     # Setup - Mix of urgent and non-urgent items
@@ -470,7 +580,8 @@ async def test_review_urgent_orders_explicit_arg_wins_over_pref(mock_urgent_cont
 @pytest.mark.asyncio
 async def test_review_urgent_orders_falls_back_to_pref_supplier(mock_urgent_context):
     """When request.supplier_codes is omitted, the saved supplier_code
-    preference is wrapped into a one-item list and applied to the query."""
+    preference is applied to the (singular) OrderPlanFilterCriteria.supplier
+    sent to the /api/OrderPlan endpoint."""
     from stocktrim_mcp_server.tools.preferences import SessionPreferences
 
     pref = SessionPreferences(supplier_code="SUP-PREF")
@@ -485,7 +596,7 @@ async def test_review_urgent_orders_falls_back_to_pref_supplier(mock_urgent_cont
 
     mock_client.order_plan.query.assert_called_once()
     filter_criteria = mock_client.order_plan.query.call_args.args[0]
-    assert filter_criteria.supplier_codes == ["SUP-PREF"]
+    assert filter_criteria.supplier == "SUP-PREF"
 
 
 @pytest.mark.asyncio
@@ -506,7 +617,7 @@ async def test_review_urgent_orders_explicit_supplier_codes_override_pref(
     await _review(request, mock_urgent_context)
 
     filter_criteria = mock_client.order_plan.query.call_args.args[0]
-    assert filter_criteria.supplier_codes == ["SUP-EXPLICIT"]
+    assert filter_criteria.supplier == "SUP-EXPLICIT"
 
 
 @pytest.mark.asyncio
@@ -530,8 +641,8 @@ async def test_review_urgent_orders_explicit_empty_clears_pref(mock_urgent_conte
     # Empty list is falsy, so the helper sends UNSET (no filter) to the API.
     from stocktrim_public_api_client.client_types import UNSET
 
-    assert filter_criteria.location_codes is UNSET
-    assert filter_criteria.supplier_codes is UNSET
+    assert filter_criteria.location is UNSET
+    assert filter_criteria.supplier is UNSET
 
 
 @pytest.mark.asyncio

--- a/stocktrim_public_api_client/utils.py
+++ b/stocktrim_public_api_client/utils.py
@@ -9,6 +9,12 @@ from typing import TYPE_CHECKING, TypeVar, overload
 
 from .client_types import UNSET, Response, Unset
 
+# How many characters of the raw response body to attach to error messages
+# when the OpenAPI client could not parse it. Bounded so HTML stack-traces
+# and similar verbose bodies don't blow up log lines / MCP tool errors, but
+# long enough for the prefix to actually identify the problem.
+_BODY_EXCERPT_LIMIT = 500
+
 if TYPE_CHECKING:
     from .generated.models.problem_details import ProblemDetails
 
@@ -65,6 +71,64 @@ class ServerError(APIError):
     """Raised when server error occurs (5xx)."""
 
     pass
+
+
+def _is_unsafe_control_char(c: str) -> bool:
+    """Identify ASCII / C1 control chars that would corrupt log output.
+
+    Covers the C0 range (``\\x00``-``\\x1f``) and DEL plus the C1 range
+    (``\\x7f``-``\\x9f``). Whitelists ``\\n``, ``\\r``, ``\\t`` — those are
+    legitimate text formatting and useful inside JSON/HTML body excerpts.
+    """
+    if c in "\n\r\t":
+        return False
+    code = ord(c)
+    return code < 0x20 or 0x7F <= code <= 0x9F
+
+
+def _body_excerpt(response: "Response[T]") -> str | None:
+    """Return a short, printable excerpt of the response body for error messages.
+
+    Returns ``None`` when the body is empty (so callers can omit the trailing
+    ``: <excerpt>`` from the message). Bodies that aren't valid UTF-8 (binary
+    blobs, etc.) fall back to a ``<N bytes, undecodable>`` placeholder so the
+    exception text stays printable. Control characters in otherwise-text
+    bodies (C0 range, C1 range, and DEL — see :func:`_is_unsafe_control_char`)
+    are escaped with ``\\xNN`` so they don't corrupt log lines. When the
+    body exceeds the limit a ``…[+N chars]`` suffix tells the caller how many
+    source characters were dropped.
+
+    The output length is strictly bounded by ``_BODY_EXCERPT_LIMIT`` (plus
+    the short ``…[+N chars]`` suffix). Without per-char accounting a body of
+    all control characters would expand 4x to ``4 * LIMIT`` after escaping;
+    the loop below stops adding chars once the *escaped* budget is spent and
+    reports the unconsumed source length in the suffix instead.
+    """
+    content = getattr(response, "content", None)
+    if not content:
+        return None
+    try:
+        text = content.decode("utf-8").strip()
+    except UnicodeDecodeError:
+        return f"<{len(content)} bytes, undecodable>"
+    if not text:
+        return None
+
+    pieces: list[str] = []
+    output_len = 0
+    consumed = 0
+    for c in text:
+        escaped_c = f"\\x{ord(c):02x}" if _is_unsafe_control_char(c) else c
+        if output_len + len(escaped_c) > _BODY_EXCERPT_LIMIT:
+            break
+        pieces.append(escaped_c)
+        output_len += len(escaped_c)
+        consumed += 1
+
+    excerpt = "".join(pieces)
+    if consumed == len(text):
+        return excerpt
+    return f"{excerpt}…[+{len(text) - consumed} chars]"
 
 
 @overload
@@ -139,7 +203,10 @@ def unwrap(
         if not raise_on_error:
             return None
 
-        # Extract error message from ProblemDetails if available
+        # Extract error message from ProblemDetails if available; fall back
+        # to a generic message plus a body excerpt so 5xx responses with
+        # unparseable bodies (HTML stack traces, plain-text errors, etc.) are
+        # debuggable from the exception alone instead of opaque.
         if problem_details:
             title = unwrap_unset(problem_details.title)
             detail = unwrap_unset(problem_details.detail)
@@ -149,7 +216,9 @@ def unwrap(
                 else (title or detail or "Unknown error")
             )
         else:
-            message = f"API error with status {response.status_code}"
+            base = f"API error with status {response.status_code}"
+            excerpt = _body_excerpt(response)
+            message = f"{base}: {excerpt}" if excerpt else base
 
         # Raise specific exception based on status code
         if response.status_code == HTTPStatus.UNAUTHORIZED:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -185,6 +185,140 @@ class TestUnwrap:
         assert exc_info.value.status_code == 500
         assert "No parsed response data" not in str(exc_info.value)
 
+    def test_unwrap_error_message_includes_body_excerpt(self):
+        """When parsed=None on an error, surface the raw body in the exception
+        message so callers can debug 5xx/415 without diving into transport logs."""
+        body = b'{"error":"required field \'location\' missing"}'
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=body,
+            headers={"Content-Type": "application/json"},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        assert "required field 'location' missing" in str(exc_info.value)
+
+    def test_unwrap_error_message_truncates_long_body(self):
+        """Very long bodies (HTML stack traces, etc.) get truncated to keep
+        log/MCP-error lines manageable, but the truncation marker preserves
+        the original length so operators know how much was dropped."""
+        long_body = b"x" * 5000
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=long_body,
+            headers={},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        message = str(exc_info.value)
+        assert "+4500 chars" in message  # 5000 total - 500 limit
+        # Message stays bounded — limit + envelope is < 700 chars.
+        assert len(message) < 700
+
+    def test_unwrap_error_message_omits_body_when_empty(self):
+        """No body → no trailing colon — keeps the bare 'API error with status N'
+        message clean for empty 5xx responses."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=b"",
+            headers={},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        assert str(exc_info.value) == "API error with status 500"
+
+    def test_unwrap_error_message_handles_undecodable_body(self):
+        """Bodies that aren't valid UTF-8 (binary blobs) fall back to a
+        ``<N bytes, undecodable>`` placeholder so the exception text stays
+        printable instead of leaking raw bytes or U+FFFD into log lines."""
+        # 0xff is an invalid UTF-8 start byte — strict decode fails.
+        content = b"\xff\xfe\x00bin"
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=content,
+            headers={},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        assert f"<{len(content)} bytes, undecodable>" in str(exc_info.value)
+
+    def test_unwrap_error_message_escapes_control_chars_in_text_body(self):
+        """Valid-UTF-8 bodies with embedded control characters (e.g. NUL from
+        a corrupted response) have those chars escaped as ``\\xNN`` so they
+        don't break log/MCP-error formatting; legitimate whitespace
+        (``\\n``, ``\\r``, ``\\t``) passes through unchanged."""
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=b"prefix\x00\x01\nstill text\t!",
+            headers={},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        msg = str(exc_info.value)
+        # Control chars escaped:
+        assert "\\x00" in msg
+        assert "\\x01" in msg
+        # Raw control chars NOT present in the message:
+        assert "\x00" not in msg
+        assert "\x01" not in msg
+        # Legitimate whitespace preserved:
+        assert "\nstill text\t!" in msg
+
+    def test_unwrap_error_message_bounds_escaped_output_for_all_controls(self):
+        """A body composed entirely of control chars expands 4x when escaped
+        (each ``\\x00`` becomes the 4-char sequence ``\\x00``). The output
+        must still be bounded to roughly ``_BODY_EXCERPT_LIMIT`` characters
+        — not 4x that — so log lines stay manageable even in pathological
+        cases."""
+        from stocktrim_public_api_client.utils import _BODY_EXCERPT_LIMIT
+
+        # 2000 NUL bytes → 8000 chars after naïve full-body escape; bounded
+        # impl should stop at the first _BODY_EXCERPT_LIMIT chars of output.
+        nul_body = b"\x00" * 2000
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=nul_body,
+            headers={},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        msg = str(exc_info.value)
+        # Each NUL escapes to 4 chars, so the budget fits LIMIT/4 source chars.
+        # The suffix reports the remaining 2000 - LIMIT/4 dropped chars.
+        kept = _BODY_EXCERPT_LIMIT // 4
+        assert f"+{2000 - kept} chars" in msg
+        # Strict upper bound: escaped excerpt ≤ limit, plus a short suffix
+        # (≤ 30 chars: "…[+NNNN chars]"). Total stays well under 4x limit.
+        assert len(msg) < _BODY_EXCERPT_LIMIT * 2
+
+    def test_unwrap_error_message_escapes_del_and_c1_controls(self):
+        """DEL (``\\x7f``) and the C1 range (``\\x80``-``\\x9f``) are also
+        control characters and should be escaped, even though they sit above
+        the C0 range. Plain ASCII printables stay unescaped."""
+        # Valid UTF-8: \x7f is single-byte ASCII DEL, \xc2\x80 is U+0080 (C1),
+        # \xc2\x9f is U+009F (last C1).
+        response: Response[Any] = Response(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content=b"ok\x7fDEL\xc2\x80C1lo\xc2\x9fhi",
+            headers={},
+            parsed=None,
+        )
+        with pytest.raises(ServerError) as exc_info:
+            unwrap(response)
+        msg = str(exc_info.value)
+        assert "\\x7f" in msg
+        assert "\\x80" in msg
+        assert "\\x9f" in msg
+        # Printable ASCII chunks should still be present:
+        assert "okDEL" not in msg  # the DEL between them got escaped
+        assert "ok\\x7fDEL" in msg
+
     def test_unwrap_404_with_unparseable_body_raises_not_found_error(self):
         """A 404 with parsed=None should raise NotFoundError, not generic APIError."""
         response: Response[Any] = Response(


### PR DESCRIPTION
## Summary

Foundation fixes for the 2026-05-26 MCP bug report (issues #2, #3, and #4 from the report).

**1. `unwrap()` now surfaces the response body excerpt on error status.**
Before: `Error calling tool 'search_products': API error with status 500` — opaque, undebuggable from outside.
After: `Error calling tool 'search_products': API error with status 500: <first 500 chars of body>…[+N chars]`.
- Bounded at 500 chars with a "…[+N chars]" suffix so log lines stay readable
- Empty bodies → no trailing `:` (clean baseline)
- Undecodable bytes → `<N bytes, undecodable>` fallback

This unblocks debugging issues #2 (`search_products` 500) and #3 (`forecasts_get_for_products` 500). Re-run those tools in your Cowork session and the error message will now include whatever StockTrim actually returned.

**2. `review_urgent_order_requirements` 415 fixed.**
Root cause: the code built `OrderPlanFilterCriteriaDto` (list-shaped, used by the V2 PO generation endpoint) and passed it to `client.order_plan.query()` which targets `/api/OrderPlan` and expects `OrderPlanFilterCriteria` (singular `location`/`supplier`/`category`). StockTrim rejected the wrong-shaped body with 415.

Switched to the singular schema. For list-shaped MCP inputs, the first element is sent to the API and `order_plan_multifilter_narrowed` is logged at WARNING so operators see further filtering was dropped (multi-filter is an upstream API limitation, not addressable here).

Bonus: the `category` filter — documented in the request schema but never plumbed through to the API — is now wired.

## Test plan

- [x] `uv run poe check` clean (ruff/ty/yamllint, 91 client + 329 MCP tests)
- [x] 4 new `test_utils.py` cases for body-excerpt formatting (basic JSON, long-body truncation, empty body, undecodable bytes)
- [x] 2 new `test_urgent_orders.py` cases pinning the `OrderPlanFilterCriteria` type (vs Dto) and the multi-element warning behavior
- [ ] Re-run the 4 failing tools from the bug report in a Cowork session against this branch:
  - `search_products(search_query="SRAM")` — should now show upstream 500 body
  - `forecasts_get_for_products(supplier_code="SRAM")` — should now show upstream 500 body
  - `review_urgent_order_requirements(supplier_codes=["SRAM"])` — should succeed (was 415)
  - `list_purchase_orders()` — still expected to return `[]` (drafts filter is a separate follow-up)

## Follow-ups (deferred)

- **#1 (drafts in list_purchase_orders):** add a `status` filter once we know how StockTrim's PO endpoint surfaces drafts. Need an API call to confirm shape.
- **#2/#3 root cause:** once you re-run with this branch and we see the upstream bodies, we'll know whether to fix in the client (params) or report upstream.
- **UX nit (`request` wrapper):** schema-flattening across the MCP tools — larger scope, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)