### PR TITLE
chore(harness): promote rebase-before-PR to CRITICAL in /open-pr and /review-pr

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -4,40 +4,64 @@ description: >-
   Open a PR for the current feature branch — validate, self-review, simplify,
   organize commits, push, create the PR, wait for CI and review, then address
   feedback. Use when implementation is complete and ready for review.
-argument-hint: "[base branch]"
-allowed-tools: Bash(gh pr *), Bash(gh api *), Bash(gh run *), Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git branch *), Bash(git stash *), Bash(git checkout *), Bash(git reset *), Bash(git rev-list *), Bash(git rev-parse *), Bash(.claude/skills/open-pr/*), Bash(.claude/skills/shared/discover-verification-cmd.sh*), Bash(.claude/skills/shared/resolve-github-context.sh*), Read
+argument-hint: '[base branch]'
+allowed-tools: Bash(gh pr *), Bash(gh api *), Bash(gh run *), Bash(git status), Bash(git diff *), Bash(git log *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git branch *), Bash(git stash *), Bash(git checkout *), Bash(git fetch *), Bash(git rebase *), Bash(git reset *), Bash(git rev-list *), Bash(git rev-parse *), Bash(jq *), Bash(.claude/skills/open-pr/*), Bash(.claude/skills/shared/discover-verification-cmd.sh*), Bash(.claude/skills/shared/resolve-github-context.sh*), Read
 ---
 
 # /open-pr — Open a Pull Request
 
-Take the current feature branch from "implementation done" to "PR open, CI green, first-round review addressed."
+Take the current feature branch from "implementation done" to "PR open, CI green,
+first-round review addressed."
 
 ## PURPOSE
 
-Ship a feature branch end-to-end: validate, self-review, push, create PR, wait for CI, address the first round of review.
+Ship a feature branch end-to-end: validate, self-review, push, create PR, wait for CI,
+address the first round of review.
 
 ## CRITICAL
 
-- **Validate before opening** — the project's verification command must pass before `gh pr create`. Don't push broken code.
-- **Self-review the full diff** — read every change before opening; never skip this and rely on reviewers.
-- **Stage specific files** — never `git add -A` or `git add .`. Intentional staging prevents accidentally committing secrets, scratch files, or unrelated changes.
-- **Use polling scripts for CI and review state** — never check review comments with `gh pr view --json`. That endpoint only returns top-level PR comments, not inline review comments attached to code lines. Use `poll-review.sh` which calls the correct API (`gh api repos/.../pulls/.../comments`).
-- **Never merge with unaddressed review comments** — every comment gets fixed, deferred with a tracked issue, or discussed. CI green does not override review feedback.
-- **No `--no-verify`** — never bypass commit hooks, type checkers, or linters. If a check fails, fix the cause.
+- **Rebase on the target branch before opening — no exceptions** —
+  `git fetch origin <base>` then check `git log HEAD..origin/<base> --oneline` first. If
+  anything appears, the branch is stale; rebase before doing anything else. Opening a PR
+  from a stale tip means: (a) CI runs against an old base — green checks here don't
+  prove the code works on `main`'s actual current state; (b) reviewers see merge
+  artifacts that aren't yours; (c) `uv.lock` drift from sibling-package releases shows
+  up mid-pre-commit; (d) GitHub auto-merge gets stuck on `mergeStateStatus=BEHIND` and
+  can't fire. Use `git rebase origin/<base>` directly, or invoke `/rebase` for conflict
+  resolution + lockfile bundling. **Same check applies before every `--force-with-lease`
+  push during the cycle** — this is exactly the failure mode that hit PR #203: a
+  fixup-and-push autosquash conflicted with commits that landed on the branch since the
+  original, because the rebase step was skipped.
+- **Validate before opening** — the project's verification command must pass before
+  `gh pr create`. Don't push broken code.
+- **Self-review the full diff** — read every change before opening; never skip this and
+  rely on reviewers.
+- **Stage specific files** — never `git add -A` or `git add .`. Intentional staging
+  prevents accidentally committing secrets, scratch files, or unrelated changes.
+- **Use polling scripts for CI and review state** — never check review comments with
+  `gh pr view --json`. That endpoint only returns top-level PR comments, not inline
+  review comments attached to code lines. Use `poll-review.sh` which calls the correct
+  API (`gh api repos/.../pulls/.../comments`).
+- **Never merge with unaddressed review comments** — every comment gets fixed, deferred
+  with a tracked issue, or discussed. CI green does not override review feedback.
+- **No `--no-verify`** — never bypass commit hooks, type checkers, or linters. If a
+  check fails, fix the cause.
 
 ## STANDARD PATH
 
-The skill runs nine phases. Each phase is short; phase headings below are the navigation index.
+The skill runs nine phases. Each phase is short; phase headings below are the navigation
+index.
 
-1. **Pre-flight** — ensure feature branch, run validation, check for existing PR
-2. **Self-review** — read the full diff, check for bugs/secrets/debug code
-3. **Simplify (optional)** — reuse, dead code, duplication
-4. **Organize commits** — logical commits with conventional format + HEREDOC
-5. **Push and create PR** — `gh pr create` with HEREDOC body
-6. **Wait for CI** — `poll-ci.sh`; fix in place if anything fails
-7. **Wait for review** — `poll-review.sh`; never skip with `gh pr view`
-8. **Address review comments** — delegate to `/review-pr`
-9. **Summary** — report PR URL, CI status, comments addressed
+1. **Pre-flight** — ensure feature branch, **rebase on latest target branch**
+   (mandatory; see CRITICAL), run validation, check for existing PR
+1. **Self-review** — read the full diff, check for bugs/secrets/debug code
+1. **Simplify (optional)** — reuse, dead code, duplication
+1. **Organize commits** — logical commits with conventional format + HEREDOC
+1. **Push and create PR** — `gh pr create` with HEREDOC body
+1. **Wait for CI** — `poll-ci.sh`; fix in place if anything fails
+1. **Wait for review** — `poll-review.sh`; never skip with `gh pr view`
+1. **Address review comments** — delegate to `/review-pr`
+1. **Summary** — report PR URL, CI status, comments addressed
 
 ## Phase 1: Pre-flight
 
@@ -48,13 +72,38 @@ The skill runs nine phases. Each phase is short; phase headings below are the na
    ```
 
    The script handles three scenarios automatically:
-   - **Unpushed commits on main** → infers branch name from commit, creates branch, resets main
+
+   - **Unpushed commits on main** → infers branch name from commit, creates branch,
+     resets main
    - **Staged/unstaged changes** → stashes, creates branch, pops
    - **Clean state** → exits 1 ("No changes to create a PR from.")
 
-2. **Determine base branch** — use `$ARGUMENTS` if provided, otherwise `main`.
+1. **Determine base branch** — use `$ARGUMENTS` if provided, otherwise `main`.
 
-3. **Discover and run validation:**
+1. **Rebase on latest target branch** — fetch the base and check freshness:
+
+   ```bash
+   git fetch origin <base>
+   git log HEAD..origin/<base> --oneline
+   ```
+
+   If any commits appear, the branch is behind — rebase before doing anything else:
+
+   ```bash
+   git rebase origin/<base>
+   # If uv.lock or other artifacts drifted post-rebase, stage them
+   # and bundle into the existing commit (or amend if it makes sense).
+   ```
+
+   The `/rebase` skill wraps this with conflict resolution and uv.lock bundling; use it
+   when conflicts are likely, otherwise the plain `git rebase` above is the canonical
+   command.
+
+   This step is **mandatory**, not optional. Skipping it produces every failure mode
+   listed in CRITICAL above. The `git fetch` is required — `origin/<base>` is a
+   remote-tracking ref that may be stale without it.
+
+1. **Discover and run validation:**
 
    ```bash
    cmd=$(.claude/skills/shared/discover-verification-cmd.sh)
@@ -63,13 +112,14 @@ The skill runs nine phases. Each phase is short; phase headings below are the na
 
    **ALL must pass.** Fix any failures before proceeding.
 
-4. **Check for existing PR**:
+1. **Check for existing PR**:
 
    ```bash
    gh pr view --json number,url,state
    ```
 
-   If a PR already exists and is open, auto-delegate to `/review-pr` — do not stop and tell the user.
+   If a PR already exists and is open, auto-delegate to `/review-pr` — do not stop and
+   tell the user.
 
 ## Phase 2: Self-review
 
@@ -102,7 +152,8 @@ Review for opportunities to simplify:
 
 If improvements are found, apply them and re-run validation.
 
-Note: This phase is optional and relies on manual review or the `/simplify` skill if available in your Claude Code environment.
+Note: This phase is optional and relies on manual review or the `/simplify` skill if
+available in your Claude Code environment.
 
 ## Phase 4: Organize commits
 
@@ -114,13 +165,15 @@ Note: This phase is optional and relies on manual review or the `/simplify` skil
    ```
 
 1. Organize changes into logical commits:
-   - If all uncommitted: group into meaningful commits (separate feature from tests, refactoring from new functionality)
+
+   - If all uncommitted: group into meaningful commits (separate feature from tests,
+     refactoring from new functionality)
    - If commits exist and are well-organized: just commit remaining changes
    - If messy (WIP, fixup): clean up
 
-2. **Stage specific files** — never use `git add -A` or `git add .`
+1. **Stage specific files** — never use `git add -A` or `git add .`
 
-3. Use conventional commit format with HEREDOC:
+1. Use conventional commit format with HEREDOC:
 
    ```bash
    git commit -m "$(cat <<'EOF'
@@ -141,7 +194,7 @@ Note: This phase is optional and relies on manual review or the `/simplify` skil
    git push -u origin <branch>
    ```
 
-2. Create PR with HEREDOC body:
+1. Create PR with HEREDOC body:
 
    ```bash
    gh pr create --base <base> --title "feat(scope): short description" --body "$(cat <<'EOF'
@@ -156,7 +209,7 @@ Note: This phase is optional and relies on manual review or the `/simplify` skil
    )"
    ```
 
-3. Print the PR URL.
+1. Print the PR URL.
 
 ## Phase 6: Wait for CI
 
@@ -166,11 +219,15 @@ Note: This phase is optional and relies on manual review or the `/simplify` skil
 
 Exit 0 = passed, exit 1 = failed (fix, commit, push, re-poll), exit 2 = timeout.
 
-**If a check fails:** fetch logs with `gh run view <run-id> --log-failed`, fix, validate locally, commit (specific files), push, resume waiting.
+**If a check fails:** fetch logs with `gh run view <run-id> --log-failed`, fix, validate
+locally, commit (specific files), push, resume waiting.
 
 ## Phase 7: Wait for review
 
-**Always use the polling script** — never check for review comments with `gh pr view --json`. That endpoint only returns top-level PR comments, not inline review comments attached to code lines. The polling script uses the correct API (`gh api repos/.../pulls/.../comments`).
+**Always use the polling script** — never check for review comments with
+`gh pr view --json`. That endpoint only returns top-level PR comments, not inline review
+comments attached to code lines. The polling script uses the correct API
+(`gh api repos/.../pulls/.../comments`).
 
 ```bash
 ctx=$(.claude/skills/shared/resolve-github-context.sh <number>)
@@ -206,21 +263,36 @@ Print:
 
 ## Important Rules
 
-- **Never dismiss review findings** — Code quality concerns are the entire point of code review. Never rationalize skipping them ("not blocking", "acceptable", "good for future refinement"). Every finding gets fixed, deferred with a tracked issue, or discussed with the reviewer. "CI is green" and "tests pass" do not override review feedback.
-- **Never merge with unaddressed comments** — All review comments must be resolved before merging. No exceptions.
+- **Never dismiss review findings** — Code quality concerns are the entire point of code
+  review. Never rationalize skipping them ("not blocking", "acceptable", "good for
+  future refinement"). Every finding gets fixed, deferred with a tracked issue, or
+  discussed with the reviewer. "CI is green" and "tests pass" do not override review
+  feedback.
+- **Never merge with unaddressed comments** — All review comments must be resolved
+  before merging. No exceptions.
 - **Validate before opening** — verification must pass before creating the PR
 - **Self-review is mandatory** — always review the full diff
-- **Simplify is optional** — run `/simplify` before opening when meaningful reuse, dead code, or duplication is likely; skip for tiny or clearly-minimal diffs
+- **Simplify is optional** — run `/simplify` before opening when meaningful reuse, dead
+  code, or duplication is likely; skip for tiny or clearly-minimal diffs
 - **Logical commits** — organize into meaningful commits, not one giant squash
 - **No shortcuts** — never use `--no-verify`, `noqa`, or `type: ignore`
 - **Fix CI in-place** — don't close and re-open
 - **Stage specific files** — never `git add -A` or `git add .`
 - **HEREDOC for messages** — always use HEREDOC for commit messages and PR bodies
-- **File issues for deferred work** — if self-review finds out-of-scope issues, create GitHub issues before opening
+- **File issues for deferred work** — if self-review finds out-of-scope issues, create
+  GitHub issues before opening
 - **Delegate to /review-pr** — don't duplicate the comment-response workflow
 
 ## Related Skills
 
-- `/review-pr` — Address review feedback (fix, commit, push, reply)
-- `/commit` — Quality-gated conventional commits
-- `/simplify` — Code simplification pass
+> Some of the skills below come from the
+> [harness-kit](https://github.com/dougborg/harness-kit) plugin at runtime (e.g.
+> `/rebase`, `/simplify`); others (`/review-pr`, `/commit`) have local overlays in
+> `.claude/skills/` that extend or specialize the upstream version. When both exist, the
+> local overlay wins.
+
+- `/rebase` — Canonical conflict-resolution wrapper with `uv.lock` bundling
+  (harness-kit)
+- `/review-pr` — Address review feedback (fix, commit, push, reply) — local overlay
+- `/commit` — Quality-gated conventional commits — local overlay
+- `/simplify` — Code simplification pass (harness-kit)

--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: pr-comments
+description: Respond to PR review comments systematically in thread context
+allowed-tools: Bash(gh api *), Bash(gh pr *), Bash(git *), Bash(jq *), Bash(.claude/skills/pr-comments/reply-to-comment.sh*), Bash(.claude/skills/shared/resolve-github-context.sh*), Bash(.claude/skills/shared/fetch-pr-context.sh*), Read
+---
+
+# /pr-comments — Respond to PR Comments
+
+Systematically respond to PR review comments, ensuring all feedback is addressed in
+thread context.
+
+## PURPOSE
+
+Reply to every unresolved PR comment with appropriate responses (fixed, already-fixed,
+or acknowledged).
+
+## CRITICAL
+
+- **ALWAYS use the reply script** —
+  `.claude/skills/pr-comments/reply-to-comment.sh {owner}/{repo} {number} {comment_id} 'body'`.
+  The script validates the comment belongs to the correct PR before posting. Never use
+  standalone `gh pr comment {number}` (loses thread context) or raw `gh api` (easy to
+  get the endpoint wrong).
+- **Reply to EVERY comment** — Nothing left unaddressed or hanging
+- **Only reply after code is live** — Wait for push to complete before responding.
+  Replies confirm fix is deployed.
+- **Batch replies per commenter when appropriate** — Multiple small changes from same
+  reviewer can be batched into one multi-item reply
+
+## ASSUMES
+
+- PR comments already exist (this is addressing feedback, not collecting it)
+- You have `gh` CLI and appropriate GitHub access
+- Code changes have been made and pushed (you're replying, not fixing)
+
+## STANDARD PATH
+
+### 1. Fetch All Unresolved Comments
+
+```bash
+ctx=$(.claude/skills/shared/resolve-github-context.sh {number})
+owner_repo=$(echo "$ctx" | jq -r '"\(.owner)/\(.repo)"')
+.claude/skills/shared/fetch-pr-context.sh "$owner_repo" {number}
+```
+
+The script returns comments with resolved status. Filter to unresolved only.
+
+### 2. Triage Each Comment
+
+For each unresolved comment:
+
+- **fix needed** → Already fixed? → Reply with: "Fixed — [what changed]"
+- **already fixed** → Reply: "Addressed in [commit] — [brief explanation]"
+- **acknowledged** → Reply: "Noted — [reasoning]. Tracked in #NNN" (with issue link)
+
+### 3. Reply in Thread
+
+Use comment ID to reply in-thread via GitHub API:
+
+```bash
+.claude/skills/pr-comments/reply-to-comment.sh {owner}/{repo} {number} {comment_id} 'Fixed — [explanation]'
+```
+
+**Never:** `gh pr comment {number} --body='...'` (loses thread context) **Never:**
+`gh api .../pulls/comments/{id}/replies` (endpoint does not exist, returns 404)
+**Never:** raw `gh api` for replies — always use the script (validates correct PR)
+
+### 4. Summary
+
+Report:
+
+- Fixed: X comments
+- Already fixed: Y comments
+- Acknowledged: Z comments
+- Any unaddressed items
+
+## EDGE CASES
+
+- [Batch replies for same reviewer] — Read DETAIL: Batching Comments (when to group,
+  when to separate)
+- [Multiple reviewers on same issue] — Read DETAIL: Multi-Reviewer Coordination
+  (consistency)
+- [Conflicting feedback] — Read DETAIL: Handling Conflicts (reconcile before replying)
+- [Comment response templates] — Read DETAIL: Response Formats
+  (fix/already-fixed/acknowledged patterns)
+
+______________________________________________________________________
+
+## DETAIL: Batching Comments
+
+When a single reviewer has multiple comments:
+
+### Batch Small Changes
+
+Group 2-3 small comments into one reply if they're related:
+
+```text
+Fixed:
+1. Added validation on line 45 (comment #1)
+2. Extracted to utility function (comment #2)
+Both validated locally before push.
+```
+
+### Keep Complex Changes Separate
+
+If responses are lengthy or unrelated, reply individually:
+
+```text
+Comment #1: Lengthy architectural discussion
+Comment #2: Simple typo fix
+→ Two separate replies (don't batch)
+```
+
+### One Reply Per Thread
+
+Multiple comments in the same thread (sub-conversation) → one reply addressing all.
+
+______________________________________________________________________
+
+## DETAIL: Multi-Reviewer Coordination
+
+When multiple reviewers comment on same code:
+
+### Consistency
+
+Ensure responses are consistent across reviewers:
+
+```text
+Reviewer A: "Extract to function"
+Reviewer B: "This function is hard to test"
+
+✅ Unified response: "Extracted to utility and added tests"
+❌ Different responses: Looks like we ignored one reviewer
+```
+
+### Timing
+
+Reply to all comments in the same push cycle. Don't reply to some, ignore others.
+
+### Addressing Conflicts
+
+If two reviewers disagree, reply:
+
+```text
+Good points from both. We've decided on approach X because [reasoning].
+Link to GitHub issue for extended discussion if needed.
+```
+
+______________________________________________________________________
+
+## DETAIL: Handling Conflicts
+
+If reviewer feedback contradicts design or project standards:
+
+### Acknowledge Respectfully
+
+```text
+I understand the concern about [issue]. However, we're using pattern X
+because [project constraint]. If you'd like to discuss alternatives,
+let's open a separate issue.
+```
+
+### Don't Dismiss
+
+Even if you disagree, acknowledge the valid concern:
+
+```text
+❌ Bad: "That's not how we do things here"
+✅ Good: "I see the readability concern. We've chosen approach X
+         because [trade-off]. Happy to discuss in future PRs."
+```
+
+### Link to Guidance
+
+If feedback relates to project standards, link to CLAUDE.md or relevant docs:
+
+```text
+Good catch. This follows pattern documented in CLAUDE.md#section.
+Let me know if the guidance is unclear.
+```
+
+______________________________________________________________________
+
+## DETAIL: Response Formats
+
+### When Code Was Fixed
+
+```text
+Fixed — [one sentence what changed].
+
+[If tests added: Also added tests for X.]
+```
+
+**Example:**
+
+```text
+Fixed — Added null check before accessing user.email on line 45.
+Also added test case for when user creation fails mid-transaction.
+```
+
+### When Issue Was Already Fixed in Prior Commit
+
+```text
+This was addressed in [commit hash] — [brief explanation].
+```
+
+**Example:**
+
+```text
+This was addressed in 3bc4e2a — Validation now happens in middleware
+before request reaches the handler.
+```
+
+### When Acknowledging but Deferring
+
+```text
+Acknowledged — [reason for deferring]. Tracked in #NNN.
+```
+
+**Example:**
+
+```text
+Acknowledged — Migrating to async/await is valuable, but out of scope
+for this PR. Tracked in #456 for next quarter.
+```
+
+### When Asking for Clarification
+
+```text
+I want to make sure I understand. Can you clarify [specific question]?
+```
+
+**Example:**
+
+```text
+I want to make sure I understand the concern. Are you concerned about
+performance at scale, or the maintainability of this pattern in general?
+```
+
+### When Declining Feedback
+
+```text
+I appreciate the suggestion. However, [reason why we're not doing this].
+Let's discuss in [GitHub issue link] if you'd like to revisit.
+```
+
+**Example:**
+
+```text
+I appreciate the suggestion to use immutable data structures. However,
+we've benchmarked this code path and mutation is actually faster here.
+See discussion in #789 for performance trade-off analysis.
+```
+
+______________________________________________________________________
+
+## IMPORTANT RULES
+
+- **ALWAYS use the reply script** — `.claude/skills/pr-comments/reply-to-comment.sh`
+  validates correct PR before posting
+- **NEVER use standalone `gh pr comment`** (loses thread context)
+- **NEVER use raw `gh api` for replies** — the script prevents wrong-PR and
+  wrong-endpoint mistakes
+- **NEVER use `/pulls/comments/{id}/replies`** — this endpoint does not exist (404)
+- **Reply AFTER push** — Confirm code is live
+- **Reply to EVERY comment** — Don't leave gaps
+- **Batch when appropriate** — Related small items can be grouped
+- **Stay respectful** — Acknowledge concern even if declining feedback
+- **Link guidance** — Reference CLAUDE.md or project docs when relevant
+
+______________________________________________________________________
+
+## RELATED
+
+- `/review-pr` — Initial PR review and address feedback
+- `/commit` — Create commits being replied to
+- [GitHub REST API: Pull Request Comments](https://docs.github.com/en/rest/pulls/comments)

--- a/.claude/skills/pr-comments/reply-to-comment.sh
+++ b/.claude/skills/pr-comments/reply-to-comment.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Reply to a PR review comment in-thread.
+#
+# Usage: reply-to-comment.sh <owner/repo> <pr-number> <comment-id> <body>
+#
+# This wraps the correct GitHub API endpoint for creating threaded replies
+# to pull request review comments. The key is the `in_reply_to` parameter
+# on POST /repos/{owner}/{repo}/pulls/{number}/comments.
+#
+# WARNING: The endpoint /pulls/comments/{id}/replies does NOT exist (returns 404).
+# This script uses the correct endpoint.
+
+set -euo pipefail
+
+if [ $# -lt 4 ]; then
+  echo "Usage: $0 <owner/repo> <pr-number> <comment-id> <body>" >&2
+  echo "" >&2
+  echo "Example:" >&2
+  echo "  $0 owner/repo 19 3025404069 'Fixed — clarified the endpoint.'" >&2
+  exit 1
+fi
+
+REPO="$1"
+PR_NUMBER="$2"
+COMMENT_ID="$3"
+BODY="$4"
+
+# Verify the comment exists and belongs to this PR
+COMMENT_PR=$(gh api "repos/${REPO}/pulls/comments/${COMMENT_ID}" --jq '.pull_request_url' 2>/dev/null || true)
+if [ -z "$COMMENT_PR" ]; then
+  echo "Error: Comment ${COMMENT_ID} not found in ${REPO}" >&2
+  exit 1
+fi
+
+# Extract PR number from the comment's pull_request_url to verify
+COMMENT_PR_NUM=$(echo "$COMMENT_PR" | grep -oE '[0-9]+$')
+if [ "$COMMENT_PR_NUM" != "$PR_NUMBER" ]; then
+  echo "Error: Comment ${COMMENT_ID} belongs to PR #${COMMENT_PR_NUM}, not PR #${PR_NUMBER}" >&2
+  echo "You may be replying to the wrong PR." >&2
+  exit 1
+fi
+
+# Post the reply in-thread
+gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+  -X POST \
+  -F in_reply_to="${COMMENT_ID}" \
+  -f body="${BODY}" \
+  --jq '{id: .id, url: .html_url}'

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: review-pr
+description: Review and address PR feedback using 6-dimensional code review
+argument-hint: '[PR number or URL]'
+allowed-tools: Bash(gh pr *), Bash(gh api *), Bash(gh repo *), Bash(git status), Bash(git branch *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git pull *), Bash(git rebase *), Bash(git stash *), Bash(git fetch *), Bash(git merge *), Bash(jq *), Bash(.claude/skills/review-pr/*), Bash(.claude/skills/shared/*), Bash(.claude/skills/pr-comments/reply-to-comment.sh*), Read
+---
+
+# /review-pr — Structured PR Review
+
+Review a PR using 6 dimensions or address unresolved review feedback systematically.
+
+## PURPOSE
+
+Analyze code changes thoroughly and respond to review comments without missing issues or
+duplicating automated findings.
+
+## CRITICAL
+
+- **Rebase on the target branch before fixing — no exceptions** — if the PR shows
+  `mergeStateStatus=BEHIND` or `git log HEAD..origin/<base> --oneline` shows anything,
+  rebase before reading comments or making code changes. Reasons: (a) comments may be
+  obsolete after the base advanced; (b) fixes pushed onto a stale branch trigger CI
+  against the still-stale base; (c) auto-merge stays blocked on BEHIND even when CI is
+  green and threads are resolved; (d) `fixup-and-push` autosquash collides with
+  intervening base commits — this is exactly the PR #203 failure mode, where a
+  mid-review force-push hit simplify commits because the rebase step was skipped. Use
+  `git rebase origin/<base>` directly, or invoke `/rebase` for conflict resolution +
+  `uv.lock` bundling.
+- **Same rebase check applies before every `--force-with-lease` after a fixup.**
+- **Never dismiss review findings** — Code quality concerns are the entire point of code
+  review. Never rationalize skipping them ("not blocking", "acceptable given dataset
+  size", "good for future refinement"). Every finding gets fixed, deferred with a
+  tracked issue, or explicitly discussed with the reviewer. "CI is green" and "tests
+  pass" do not override review feedback. Merging with unaddressed findings is forbidden.
+- **Never merge without addressing all comments** — Every comment must be resolved
+  (fixed, acknowledged with issue link, or discussed) before merging. No exceptions. If
+  you think a finding is wrong, reply explaining why — don't silently skip it.
+- **Never duplicate automated findings** — Codecov, linters, type checkers, and CI
+  checks already flag style/type/coverage issues. Skip these unless adding important
+  context.
+- **Explain the "why", not just the "what"** — Comments like "break this into a
+  function" are weak. Explain impact: "This reduces complexity from O(n²) to O(n)" or
+  "Improves testability by isolating mutation logic."
+- **Use the review prompt template** (in DETAIL) for consistency across reviews
+- **Reply to EVERY comment — automatically** — Fix → push → reply is ONE atomic
+  sequence. Never stop after pushing. The replies are what close the loop for reviewers.
+  Nothing left hanging or unaddressed.
+- **Fix first, reply after push** — Confirm the fix is live before responding. But never
+  stop at "fix pushed" — the replies are mandatory, not a follow-up task.
+- **Reply to the correct PR** — When fixes are made in a follow-up PR, reply on THAT
+  PR's comments, not the original. When fetching review comments or selecting comment
+  IDs (e.g., via `gh pr view` or `gh api repos/{owner}/{repo}/pulls/{number}/comments`),
+  always verify the PR number matches the PR you're actually working on. Replying to the
+  wrong PR is invisible to reviewers and leaves the actual PR unaddressed.
+
+## ASSUMES
+
+- You have GitHub CLI (`gh`) installed and authenticated
+- The PR exists and is accessible to you
+- Project has a verification command (test suite, linter, type checker)
+
+## STANDARD PATH
+
+### 1. Identify PR and Mode
+
+```bash
+/review-pr [PR#]                    # Or: /review-pr (current branch)
+gh pr view <PR#> --json state,reviews
+```
+
+- **No review comments** → Mode A: Initial review (analyze with code-reviewer agent)
+- **Unresolved comments** → Mode B: Address feedback (fix issues, validate, reply)
+
+### 2. Sync branch with target (mandatory before either mode)
+
+Check out the PR's head branch, then rebase against the latest base. See CRITICAL — this
+is not optional:
+
+```bash
+head_ref=$(gh pr view <PR#> --json headRefName --jq '.headRefName')
+base_ref=$(gh pr view <PR#> --json baseRefName --jq '.baseRefName')
+gh pr checkout <PR#>
+test "$(git branch --show-current)" = "$head_ref"
+
+git fetch origin "$base_ref"
+git log "HEAD..origin/$base_ref" --oneline    # any commits? rebase before doing anything else.
+git rebase "origin/$base_ref"
+```
+
+If `uv.lock` or other artifacts drift post-rebase, bundle them into the rebased commit
+(`git add uv.lock && git commit --amend --no-edit`) and `git push --force-with-lease`.
+After the rebase, re-fetch the comment list — some comments may now reference
+deleted/moved lines and need to be re-classified.
+
+### 3. Mode A: Initial Review
+
+```bash
+gh pr view <PR#> --json title,body,diff
+[Invoke code-reviewer agent with PR context]
+Organize findings: BLOCKING → SUGGESTION → NITPICK
+Post structured review via gh pr review
+```
+
+### 4. Mode B: Address Feedback
+
+```bash
+[For each unresolved comment]
+1. Read affected code
+2. Fix or acknowledge
+3. Run project verification (test suite, lint, type-check)
+4. Re-rebase if base advanced again, then commit, push
+5. Reply to EVERY comment in-thread (this step is NOT optional)
+```
+
+**Steps 4-5 are atomic.** Never finish at "pushed fixes" — always continue to reply to
+every comment before reporting done. See DETAIL: Mode B Workflow.
+
+## EDGE CASES
+
+- [Large PRs with many files] — Read DETAIL: Handling Large PRs (sample files, skip
+  boilerplate)
+- [Merge conflicts during review] — Read DETAIL: Conflict Resolution (rebase, resolve,
+  continue)
+- [CI failures blocking review] — Read DETAIL: CI Failures (distinguish code vs.
+  infrastructure issues)
+- [Review prompt template] — Read DETAIL: Review Prompt Template (consistency guide)
+- [Responding to comments] — Read DETAIL: Comment Response Format
+  (fix/deferred/already-fixed patterns)
+
+______________________________________________________________________
+
+## DETAIL: Handling Large PRs
+
+For PRs with many changed files or thousands of lines:
+
+1. **Skip boilerplate** — Auto-generated code, vendor updates, large diffs from mass
+   refactoring
+1. **Sample by category** — Review logic changes, skip formatting-only files
+1. **Focus on critical paths** — Auth, payments, data mutation, API contracts first
+1. **Ask for split if necessary** — If review is >1 hour, ask author to break into
+   smaller PRs
+
+**Example:**
+
+```text
+This PR is quite large (47 files, 2500 lines). I've reviewed:
+- Core auth changes (critical path)
+- Data mutation logic (sampled 5 files for pattern)
+- Tests (coverage spot-check)
+
+Blocked on: Vendor update changes (auto-generated, skipping).
+Recommendation: For future PRs, split refactors by domain
+(auth, API, database) for focused reviews.
+```
+
+______________________________________________________________________
+
+## DETAIL: Conflict Resolution
+
+If the PR has merge conflicts, the rebase from STANDARD PATH step 2 will surface them.
+Resolve in place:
+
+```bash
+# You're already on the PR's head branch from gh pr checkout.
+# $base_ref was set in STANDARD PATH step 2 (gh pr view ... --json baseRefName).
+git rebase "origin/$base_ref"
+# Resolve conflicts in each file (keep our branch's intent integrated with base changes)
+git add <resolved-files>
+git rebase --continue
+git push --force-with-lease origin HEAD:refs/heads/<branch-name>
+```
+
+If the conflicts originated from an explicit `git merge` instead (e.g., GitHub's "Update
+branch" button created a merge commit on the remote), pull that merge first with
+`git pull --no-rebase` and resolve normally.
+
+**Conflicts can invalidate prior comments** — recheck affected sections after resolving.
+
+______________________________________________________________________
+
+## DETAIL: CI Failures
+
+Check CI status before responding to review comments:
+
+```bash
+gh pr view {number} --json mergeable,mergeStateStatus
+gh pr checks {number}
+```
+
+**If code-related** (lint, type, test failure):
+
+1. Fix immediately
+1. Run project verification locally
+1. Commit, rebase (see CRITICAL — fetch base + rebase before every force-push), push
+
+**If infrastructure-related** (flaky CI, timeout, infrastructure issue):
+
+1. Document in response
+1. Don't block on it
+1. Link to infrastructure ticket if available
+
+**Always sync the branch and resolve conflicts/build failures before addressing review
+comments** — review comments may no longer apply after a rebase + base advance.
+
+______________________________________________________________________
+
+## DETAIL: Review Prompt Template
+
+Use this structure for consistent, thorough reviews (avoid repeating automated
+findings):
+
+```markdown
+# Review: [PR Title]
+
+## What This Changes
+
+[1-2 sentences summarizing the change and its impact]
+
+## 6-Dimensional Analysis
+
+### Correctness
+- [Semantic correctness, type safety, logic]
+- [Any potential bugs or edge cases]
+
+### Design
+- [Architecture, interfaces, patterns vs. project conventions]
+- [Trade-offs and alternatives considered?]
+
+### Readability
+- [Naming clarity, documentation, code flow]
+- [Any confusing sections?]
+
+### Performance
+- [Efficiency, algorithms, resource usage]
+- [Any obvious optimizations possible?]
+
+### Testing
+- [Test coverage for new code]
+- [Edge cases and error conditions covered?]
+
+### Security
+- [Input validation, auth, secrets, injection risks]
+- [Any exposed internals or vulnerabilities?]
+
+## Findings
+
+### BLOCKING (must fix before merge)
+[Only items that break functionality or violate critical constraints]
+
+### SUGGESTION (worth addressing)
+[Improvements that enhance quality, maintainability, or safety]
+
+### NITPICK (nice-to-have)
+[Style, naming, minor clarity suggestions]
+
+### What Looks Good
+[Highlight strong aspects: good patterns, clever solutions, solid testing]
+
+## Summary
+- Verdict: Approved / Changes requested / Comment
+- Ready to merge after addressing blocking items
+```
+
+______________________________________________________________________
+
+## DETAIL: Comment Response Format
+
+Reply to each comment with one of these patterns:
+
+### Fix Implemented
+
+```text
+Fixed — [describe what changed].
+[If tests added: Also added tests for X].
+```
+
+### Already Fixed in Prior Commit
+
+```text
+This was addressed in [commit hash] — [brief explanation].
+```
+
+### Acknowledged but Deferred
+
+```text
+Acknowledged — [reason for deferral].
+Tracked in #NNN [link to GitHub issue].
+```
+
+### Cannot Reproduce or Misunderstanding
+
+```text
+I wasn't able to reproduce this. Can you clarify [specific question]?
+```
+
+______________________________________________________________________
+
+## DETAIL: Mode A Workflow
+
+Initial PR review (no comments yet).
+
+### 1. Fetch PR Context
+
+```bash
+ctx=$(.claude/skills/shared/resolve-github-context.sh <PR#>)
+owner_repo=$(echo "$ctx" | jq -r '"\(.owner)/\(.repo)"')
+.claude/skills/shared/fetch-pr-context.sh "$owner_repo" <PR#>
+```
+
+### 2. Invoke code-reviewer Agent
+
+Pass compiled context:
+
+```text
+PR Title: [title]
+Author: [author]
+Description: [body]
+Labels: [labels]
+Diff: [patch]
+Existing Comments: [any automated reviewer comments]
+```
+
+Agent returns: 6D analysis + findings organized by severity.
+
+### 3. Present Findings
+
+```text
+BLOCKING: [list items that must be fixed]
+SUGGESTION: [list improvements]
+NITPICK: [list nice-to-haves]
+What Looks Good: [highlight strengths]
+```
+
+### 4. Post Review
+
+```bash
+gh pr review <PR#> --approve    # or --request-changes / --comment
+```
+
+______________________________________________________________________
+
+## DETAIL: Mode B Workflow
+
+Address unresolved review feedback.
+
+### 1. Sync branch first
+
+See STANDARD PATH step 2 — `gh pr checkout`, fetch base, rebase. This is **mandatory**
+and must happen before fetching comments (some may become obsolete after the rebase).
+
+### 2. Fetch Unresolved Comments
+
+```bash
+ctx=$(.claude/skills/shared/resolve-github-context.sh {number})
+owner_repo=$(echo "$ctx" | jq -r '"\(.owner)/\(.repo)"')
+.claude/skills/review-pr/fetch-unresolved-comments.sh "$owner_repo" {number}
+```
+
+Returns JSON array of unresolved comments with id, path, line, body, author. Resolved
+threads are already filtered out.
+
+### 3. Triage Each Comment
+
+Read affected code. Classify:
+
+- **fix needed** — code change required
+- **already fixed** — issue addressed in prior commit
+- **acknowledge** — valid point but deferring (must file GitHub issue)
+
+### 4. Fix All Issues
+
+Make code changes. Validate:
+
+```bash
+cmd=$(.claude/skills/shared/discover-verification-cmd.sh)
+eval "$cmd"   # ALL must pass
+```
+
+### 5. Re-rebase if base advanced, then Commit and Push
+
+**Before every force-push, re-check the base** (see CRITICAL — autosquash conflicts with
+stale branches are the exact PR #203 failure mode):
+
+```bash
+# $base_ref was set in STANDARD PATH step 2; re-fetch if it's not in scope.
+git fetch origin "$base_ref"
+git log "HEAD..origin/$base_ref" --oneline    # any commits? rebase first.
+git rebase "origin/$base_ref"                  # only if commits appeared
+```
+
+Then use the fixup-and-push script (stages, creates fixup commit, autosquash rebases,
+force-pushes):
+
+```bash
+.claude/skills/review-pr/fixup-and-push.sh "$base_ref" "original commit subject" <file1> <file2> ...
+```
+
+### 6. Reply to Each Comment (After Push)
+
+**Verify the PR number first** — confirm you're replying on the correct PR (e.g., via
+`gh pr view` or the web UI). If fixes were made in a follow-up PR, reply on that PR, not
+the original.
+
+Use the reply script — it validates the comment belongs to the correct PR before
+posting:
+
+```bash
+.claude/skills/pr-comments/reply-to-comment.sh {owner}/{repo} {number} {comment_id} 'Fixed — [explanation]'
+```
+
+**Never reply before pushing** — replies confirm fix is live.
+
+### 7. Resolve Review Threads
+
+After replying to all comments, resolve all review threads to clear the "changes
+requested" status:
+
+```bash
+resolved=$(.claude/skills/shared/resolve-all-threads.sh {owner}/{repo} {number})
+echo "Resolved $resolved review threads"
+```
+
+### 8. Summary
+
+Print results:
+
+- Fixed: X comments
+- Acknowledged: Y comments
+- Already fixed: Z comments
+- Threads resolved: X
+- Validation: PASSED/FAILED
+- Any unaddressed items
+
+______________________________________________________________________
+
+## IMPORTANT RULES
+
+- **Rebase before every force-push** — Stale branches cause autosquash conflicts, BEHIND
+  status, and obsolete comments. See CRITICAL.
+- **Never dismiss findings** — Every review finding gets fixed or deferred with an
+  issue. Never rationalize merging with unaddressed comments.
+- **Never merge with open comments** — All comments resolved before merge. No
+  exceptions.
+- **Never duplicate automated findings** — Linters, type checkers, CI checks already
+  flag these
+- **Explain the why** — Don't just say "improve this", explain impact (perf, complexity,
+  testability)
+- **Reply to every comment — automatically** — Push + reply is atomic. Never stop at
+  "pushed". Nothing left hanging.
+- **Fix first, reply after** — Push must complete before replying. But replying is
+  mandatory, not a separate task.
+- **Clean history** — Use fixup + autosquash, no "address review" commits
+- **No shortcuts** — Never use `--no-verify`, `# noqa`, `type: ignore`
+- **Deferred work needs issues** — Acknowledged items must link to `gh issue create`
+  ticket
+- **Stage specific files** — Never `git add -A` or `git add .`
+- **Use HEREDOC** — Pass commit messages via HEREDOC (not inline)
+
+______________________________________________________________________
+
+## RELATED
+
+> Some of the skills below come from the
+> [harness-kit](https://github.com/dougborg/harness-kit) plugin at runtime (e.g.
+> `/rebase`); others (`/code-reviewer`, `/pr-comments`, `/commit`) have local overlays
+> in `.claude/skills/` that extend or specialize the upstream version. When both exist,
+> the local overlay wins.
+
+- `/rebase` — Canonical conflict-resolution wrapper with `uv.lock` bundling
+  (harness-kit)
+- `/code-reviewer` — 6-dimensional review reference — local overlay
+- `/pr-comments` — Systematic reply workflow (alternative to this skill's Mode B) —
+  local overlay
+- `/commit` — Quality-gated conventional commits — local overlay
+- `code-reviewer` agent — Automated 6D analysis (spawned by this skill)

--- a/.claude/skills/review-pr/fetch-unresolved-comments.sh
+++ b/.claude/skills/review-pr/fetch-unresolved-comments.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Fetch unresolved review comments for a PR.
+#
+# Usage: fetch-unresolved-comments.sh <owner/repo> <pr-number>
+# Output: JSON array of unresolved comments with id, path, line, body, author
+#
+# Uses GraphQL to get resolved status, then filters to unresolved only.
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <owner/repo> <pr-number>" >&2
+  exit 1
+fi
+
+REPO="$1"
+PR_NUMBER="$2"
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+read -r -d '' query <<'GRAPHQL' || true
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100) {
+          nodes {
+            isResolved
+            comments(first: 100) {
+              nodes {
+                id
+                databaseId
+                body
+                path
+                line
+                author { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+GRAPHQL
+# For each unresolved thread, surface the LATEST comment. A thread can
+# accumulate multiple comments (reviewer's original + author's reply +
+# reviewer's follow-up); picking `[0]` would return the original request
+# even after newer activity, missing follow-up asks. `[-1]` gives the
+# most recent ask, which is what the "reply to every comment" workflow
+# actually needs. The reply itself attaches to the thread regardless of
+# which comment ID is used as the anchor.
+gh api graphql -f query="$query" \
+  -F "owner=$OWNER" -F "repo=$REPO_NAME" -F "number=$PR_NUMBER" \
+  --jq '[
+    .data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.isResolved | not)
+    | .comments.nodes[-1]
+    | {id: .databaseId, path: .path, line: .line, body: .body, author: .author.login}
+  ]'

--- a/.claude/skills/review-pr/fixup-and-push.sh
+++ b/.claude/skills/review-pr/fixup-and-push.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Stage files, create fixup commit, autosquash rebase, and push.
+#
+# Usage: fixup-and-push.sh <base-branch> <original-commit-subject> <files...>
+# Example: fixup-and-push.sh main "feat(auth): add login" src/auth.ts src/auth.test.ts
+#
+# Creates a fixup commit targeting the original commit subject,
+# then rebases with --autosquash and force-pushes with lease.
+
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+  echo "Usage: $0 <base-branch> <original-commit-subject> <files...>" >&2
+  exit 1
+fi
+
+base="$1"
+shift
+subject="$1"
+shift
+files=("$@")
+
+# Stage specific files (never git add -A)
+git add "${files[@]}"
+
+# Create fixup commit
+git commit -m "$(
+  cat <<EOF
+fixup! ${subject}
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+
+# Autosquash rebase
+git fetch origin "$base"
+git rebase --autosquash "origin/${base}"
+
+# Force push with lease
+git push --force-with-lease

--- a/.harness-lock.json
+++ b/.harness-lock.json
@@ -26,7 +26,30 @@
     ".claude/skills/open-pr/SKILL.md": {
       "source": "harness-kit",
       "modified": true,
-      "modification_note": "Rewrote ${CLAUDE_PLUGIN_ROOT} → .claude; closed fences with bare ```; resolved Simplify-optional-vs-mandatory contradiction. Hoist candidate."
+      "modification_note": "Rewrote ${CLAUDE_PLUGIN_ROOT} → .claude; closed fences with bare ```; resolved Simplify-optional-vs-mandatory contradiction; added CRITICAL rebase-before-PR bullet + Phase 1 rebase step (issue #180). Hoist candidate."
+    },
+    ".claude/skills/review-pr/SKILL.md": {
+      "source": "harness-kit",
+      "modified": true,
+      "modification_note": "Project-local overlay copying upstream + adding CRITICAL rebase-before-fix bullet, mandatory STANDARD PATH sync step, and re-rebase guidance in Mode B (issue #180). Hoist candidate."
+    },
+    ".claude/skills/review-pr/fetch-unresolved-comments.sh": {
+      "source": "harness-kit",
+      "modified": true,
+      "modification_note": "Fixed two upstream bugs: (1) jq filter now selects .comments.nodes[-1] (latest comment) instead of [0] (oldest) — the original picked the reviewer ORIGINAL comment even after follow-up asks, missing newer activity; (2) added line field to GraphQL selection + jq output to match header docstring promise. Worth upstreaming to harness-kit."
+    },
+    ".claude/skills/review-pr/fixup-and-push.sh": {
+      "source": "harness-kit",
+      "modified": false
+    },
+    ".claude/skills/pr-comments/SKILL.md": {
+      "source": "harness-kit",
+      "modified": true,
+      "modification_note": "Rewrote ${CLAUDE_PLUGIN_ROOT}/skills/ → .claude/skills/ to match repo overlay convention (allowed-tools + 5 in-body refs). Hoist candidate."
+    },
+    ".claude/skills/pr-comments/reply-to-comment.sh": {
+      "source": "harness-kit",
+      "modified": false
     },
     ".claude/skills/open-pr/ensure-feature-branch.sh": {
       "source": "harness-kit",


### PR DESCRIPTION
## Summary

Promotes the rebase-before-PR rule from STANDARD PATH (where agents skim past it) to **CRITICAL** in both `/open-pr` and `/review-pr` skills. Mirrors [katana commit `c5cf718`](https://github.com/dougborg/katana-openapi-client/commit/c5cf718).

In addition, completes the local overlay for `/review-pr` and `/pr-comments` (scripts were referenced but didn't exist locally — caught during review and addressed in subsequent commits, see "Scope expansion" below).

Closes #180.

## Why now

PR #203 hit this exact failure mode in the same session that opened issue #180: a `fixup-and-push` autosquash collided with intervening `main` commits because the branch wasn't rebased before the force-push. Katana hit it ~5x before promoting the rule.

The failure modes that the new CRITICAL bullet calls out:

- CI green but `mergeStateStatus=BEHIND` blocks auto-merge
- `uv.lock` drift surfaces mid-pre-commit
- Reviewers see merge artifacts that aren't ours
- Review comments become obsolete after base advances
- `fixup-and-push` autosquash conflicts with newer commits (the #203 incident)

## Scope expansion during review

The PR originally was prose-only changes to two SKILL.md files. Review feedback surfaced that the new `/review-pr` SKILL.md referenced helper scripts (`fetch-unresolved-comments.sh`, `fixup-and-push.sh`, `reply-to-comment.sh`) using `.claude/skills/...` paths — but those scripts only existed in the harness-kit plugin path, not the repo. Rather than retract the path substitution, the overlay was completed by copying the missing scripts locally (matching the pattern used by `.claude/skills/open-pr/` and `.claude/skills/shared/`, which are also full local overlays).

While completing the overlay, two upstream bugs in `fetch-unresolved-comments.sh` were also fixed (worth upstreaming to harness-kit):
1. Header docstring claimed `line` field but jq filter omitted it — added.
2. `.comments.nodes[0]` selected the OLDEST comment in a thread, missing reviewer follow-ups — changed to `[-1]` (latest).

## Changes

| File | Change |
|---|---|
| `.claude/skills/open-pr/SKILL.md` | CRITICAL rebase bullet + Phase 1 rebase step + `Bash(git fetch *)` / `Bash(git rebase *)` added to allowed-tools |
| `.claude/skills/review-pr/SKILL.md` | **New project-local overlay** — CRITICAL rebase bullet, mandatory sync step (`gh pr checkout` + rebase), re-rebase before every force-push in Mode B, `Bash(git branch *)` / `Bash(git pull *)` / `Bash(jq *)` added to allowed-tools |
| `.claude/skills/review-pr/fetch-unresolved-comments.sh` | **New overlay** (copied from harness-kit) + bug fixes: added `line` field; switched `[0]` → `[-1]` for latest comment in a thread |
| `.claude/skills/review-pr/fixup-and-push.sh` | **New overlay** (copied verbatim from harness-kit) |
| `.claude/skills/pr-comments/SKILL.md` | **New overlay** — `${CLAUDE_PLUGIN_ROOT}/skills/...` paths rewritten to `.claude/skills/...` |
| `.claude/skills/pr-comments/reply-to-comment.sh` | **New overlay** (copied verbatim from harness-kit) |
| `.harness-lock.json` | Records 5 new overlay entries with provenance + modification notes |

## Test plan

- [x] `uv run poe check` passes (format, mdformat, ruff, ty, yamllint, 96 client + 365 MCP tests)
- [x] Pre-commit hooks pass (mdformat reformatted prose-flow; re-committed clean per CLAUDE.md no-`--no-verify` rule)
- [x] Smoke test: `.claude/skills/review-pr/fetch-unresolved-comments.sh dougborg/stocktrim-openapi-client 213` returns valid JSON with `line` field populated; `[-1]` correctly surfaces the latest comment in multi-comment threads (verified by self-eating-dogfood — the script was used during this PR's own review cycles)
- [x] Allowlist audit: every git subcommand used in each SKILL.md body has a corresponding entry in `allowed-tools` (validated via `grep -oE 'git [a-z][a-z-]*' SKILL.md | sort -u` vs the frontmatter)
- [x] No `${CLAUDE_PLUGIN_ROOT}` references remain in any of the local-overlay SKILL.md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)