### PR TITLE
fix(client): tolerate null supplier and purchaseOrderLineItems on PurchaseOrder DTOs

### DIFF
--- a/scripts/regenerate_client.py
+++ b/scripts/regenerate_client.py
@@ -173,12 +173,16 @@ def add_nullable_to_date_fields(spec_path: Path) -> bool:
                 "externalId",  # string
                 "referenceNumber",  # string
                 "location",  # object
+                "supplier",  # object ($ref PurchaseOrderSupplier) — issue #214
+                "purchaseOrderLineItems",  # array — issue #214
             ],
             "PurchaseOrderRequestDto": [
                 "orderDate",  # date-time - needs to be nullable to clear dates on update
                 "externalId",  # string
                 "referenceNumber",  # string
                 "location",  # object
+                "supplier",  # object ($ref PurchaseOrderSupplier) — issue #214
+                "purchaseOrderLineItems",  # array — issue #214
             ],
             "PurchaseOrderSupplier": [
                 "supplierCode",  # string

--- a/stocktrim-openapi.yaml
+++ b/stocktrim-openapi.yaml
@@ -1801,9 +1801,6 @@ components:
           nullable: true
       additionalProperties: false
     PurchaseOrderRequestDto:
-      required:
-      - purchaseOrderLineItems
-      - supplier
       type: object
       properties:
         orderDate:
@@ -1819,7 +1816,9 @@ components:
           format: date-time
           nullable: true
         supplier:
-          $ref: '#/components/schemas/PurchaseOrderSupplier'
+          allOf:
+          - $ref: '#/components/schemas/PurchaseOrderSupplier'
+          nullable: true
         externalId:
           type: string
           nullable: true
@@ -1839,11 +1838,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PurchaseOrderLineItem'
+          nullable: true
       additionalProperties: false
     PurchaseOrderResponseDto:
-      required:
-      - purchaseOrderLineItems
-      - supplier
       type: object
       properties:
         id:
@@ -1865,7 +1862,9 @@ components:
           format: date-time
           nullable: true
         supplier:
-          $ref: '#/components/schemas/PurchaseOrderSupplier'
+          allOf:
+          - $ref: '#/components/schemas/PurchaseOrderSupplier'
+          nullable: true
         externalId:
           type: string
           nullable: true
@@ -1885,6 +1884,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PurchaseOrderLineItem'
+          nullable: true
       additionalProperties: false
     PurchaseOrderStatusDto:
       enum:

--- a/stocktrim_public_api_client/generated/models/purchase_order_request_dto.py
+++ b/stocktrim_public_api_client/generated/models/purchase_order_request_dto.py
@@ -23,40 +23,32 @@ T = TypeVar("T", bound="PurchaseOrderRequestDto")
 class PurchaseOrderRequestDto:
     """
     Attributes:
-        supplier (PurchaseOrderSupplier):
-        purchase_order_line_items (list[PurchaseOrderLineItem]):
         order_date (datetime.datetime | None | Unset):
         created_date (datetime.datetime | None | Unset):
         fully_received_date (datetime.datetime | None | Unset):
+        supplier (None | PurchaseOrderSupplier | Unset):
         external_id (None | str | Unset):
         reference_number (None | str | Unset):
         client_reference_number (None | str | Unset):
         location (None | PurchaseOrderLocation | Unset):
         status (PurchaseOrderStatusDto | Unset):
+        purchase_order_line_items (list[PurchaseOrderLineItem] | None | Unset):
     """
 
-    supplier: PurchaseOrderSupplier
-    purchase_order_line_items: list[PurchaseOrderLineItem]
     order_date: datetime.datetime | None | Unset = UNSET
     created_date: datetime.datetime | None | Unset = UNSET
     fully_received_date: datetime.datetime | None | Unset = UNSET
+    supplier: None | PurchaseOrderSupplier | Unset = UNSET
     external_id: None | str | Unset = UNSET
     reference_number: None | str | Unset = UNSET
     client_reference_number: None | str | Unset = UNSET
     location: None | PurchaseOrderLocation | Unset = UNSET
     status: PurchaseOrderStatusDto | Unset = UNSET
+    purchase_order_line_items: list[PurchaseOrderLineItem] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.purchase_order_location import PurchaseOrderLocation
-
-        supplier = self.supplier.to_dict()
-
-        purchase_order_line_items = []
-        for purchase_order_line_items_item_data in self.purchase_order_line_items:
-            purchase_order_line_items_item = (
-                purchase_order_line_items_item_data.to_dict()
-            )
-            purchase_order_line_items.append(purchase_order_line_items_item)
+        from ..models.purchase_order_supplier import PurchaseOrderSupplier
 
         order_date: None | str | Unset
         if isinstance(self.order_date, Unset):
@@ -81,6 +73,14 @@ class PurchaseOrderRequestDto:
             fully_received_date = self.fully_received_date.isoformat()
         else:
             fully_received_date = self.fully_received_date
+
+        supplier: dict[str, Any] | None | Unset
+        if isinstance(self.supplier, Unset):
+            supplier = UNSET
+        elif isinstance(self.supplier, PurchaseOrderSupplier):
+            supplier = self.supplier.to_dict()
+        else:
+            supplier = self.supplier
 
         external_id: None | str | Unset
         if isinstance(self.external_id, Unset):
@@ -112,20 +112,33 @@ class PurchaseOrderRequestDto:
         if not isinstance(self.status, Unset):
             status = self.status.value
 
+        purchase_order_line_items: list[dict[str, Any]] | None | Unset
+        if isinstance(self.purchase_order_line_items, Unset):
+            purchase_order_line_items = UNSET
+        elif isinstance(self.purchase_order_line_items, list):
+            purchase_order_line_items = []
+            for (
+                purchase_order_line_items_type_0_item_data
+            ) in self.purchase_order_line_items:
+                purchase_order_line_items_type_0_item = (
+                    purchase_order_line_items_type_0_item_data.to_dict()
+                )
+                purchase_order_line_items.append(purchase_order_line_items_type_0_item)
+
+        else:
+            purchase_order_line_items = self.purchase_order_line_items
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "supplier": supplier,
-                "purchaseOrderLineItems": purchase_order_line_items,
-            }
-        )
+        field_dict.update({})
         if order_date is not UNSET:
             field_dict["orderDate"] = order_date
         if created_date is not UNSET:
             field_dict["createdDate"] = created_date
         if fully_received_date is not UNSET:
             field_dict["fullyReceivedDate"] = fully_received_date
+        if supplier is not UNSET:
+            field_dict["supplier"] = supplier
         if external_id is not UNSET:
             field_dict["externalId"] = external_id
         if reference_number is not UNSET:
@@ -136,6 +149,8 @@ class PurchaseOrderRequestDto:
             field_dict["location"] = location
         if status is not UNSET:
             field_dict["status"] = status
+        if purchase_order_line_items is not UNSET:
+            field_dict["purchaseOrderLineItems"] = purchase_order_line_items
 
         return field_dict
 
@@ -146,16 +161,6 @@ class PurchaseOrderRequestDto:
         from ..models.purchase_order_supplier import PurchaseOrderSupplier
 
         d = dict(src_dict)
-        supplier = PurchaseOrderSupplier.from_dict(d.pop("supplier"))
-
-        purchase_order_line_items = []
-        _purchase_order_line_items = d.pop("purchaseOrderLineItems")
-        for purchase_order_line_items_item_data in _purchase_order_line_items:
-            purchase_order_line_items_item = PurchaseOrderLineItem.from_dict(
-                cast(Mapping[str, Any], purchase_order_line_items_item_data)
-            )
-
-            purchase_order_line_items.append(purchase_order_line_items_item)
 
         def _parse_order_date(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -212,6 +217,25 @@ class PurchaseOrderRequestDto:
             d.pop("fullyReceivedDate", UNSET)
         )
 
+        def _parse_supplier(data: object) -> None | PurchaseOrderSupplier | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                supplier_type_1 = PurchaseOrderSupplier.from_dict(
+                    cast(Mapping[str, Any], data)
+                )
+
+                return supplier_type_1
+            except:  # noqa: E722
+                pass
+            return cast(None | PurchaseOrderSupplier | Unset, data)
+
+        supplier = _parse_supplier(d.pop("supplier", UNSET))
+
         def _parse_external_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -267,17 +291,54 @@ class PurchaseOrderRequestDto:
         else:
             status = PurchaseOrderStatusDto(_status)
 
+        def _parse_purchase_order_line_items(
+            data: object,
+        ) -> list[PurchaseOrderLineItem] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                purchase_order_line_items_type_0 = []
+                _purchase_order_line_items_type_0 = data
+                for (
+                    purchase_order_line_items_type_0_item_data
+                ) in _purchase_order_line_items_type_0:
+                    purchase_order_line_items_type_0_item = (
+                        PurchaseOrderLineItem.from_dict(
+                            cast(
+                                Mapping[str, Any],
+                                purchase_order_line_items_type_0_item_data,
+                            )
+                        )
+                    )
+
+                    purchase_order_line_items_type_0.append(
+                        purchase_order_line_items_type_0_item
+                    )
+
+                return purchase_order_line_items_type_0
+            except:  # noqa: E722
+                pass
+            return cast(list[PurchaseOrderLineItem] | None | Unset, data)
+
+        purchase_order_line_items = _parse_purchase_order_line_items(
+            d.pop("purchaseOrderLineItems", UNSET)
+        )
+
         purchase_order_request_dto = cls(
-            supplier=supplier,
-            purchase_order_line_items=purchase_order_line_items,
             order_date=order_date,
             created_date=created_date,
             fully_received_date=fully_received_date,
+            supplier=supplier,
             external_id=external_id,
             reference_number=reference_number,
             client_reference_number=client_reference_number,
             location=location,
             status=status,
+            purchase_order_line_items=purchase_order_line_items,
         )
 
         return purchase_order_request_dto

--- a/stocktrim_public_api_client/generated/models/purchase_order_response_dto.py
+++ b/stocktrim_public_api_client/generated/models/purchase_order_response_dto.py
@@ -23,44 +23,36 @@ T = TypeVar("T", bound="PurchaseOrderResponseDto")
 class PurchaseOrderResponseDto:
     """
     Attributes:
-        supplier (PurchaseOrderSupplier):
-        purchase_order_line_items (list[PurchaseOrderLineItem]):
         id (int | Unset):
         message (None | str | Unset):
         order_date (datetime.datetime | None | Unset):
         created_date (datetime.datetime | None | Unset):
         fully_received_date (datetime.datetime | None | Unset):
+        supplier (None | PurchaseOrderSupplier | Unset):
         external_id (None | str | Unset):
         reference_number (None | str | Unset):
         client_reference_number (None | str | Unset):
         location (None | PurchaseOrderLocation | Unset):
         status (PurchaseOrderStatusDto | Unset):
+        purchase_order_line_items (list[PurchaseOrderLineItem] | None | Unset):
     """
 
-    supplier: PurchaseOrderSupplier
-    purchase_order_line_items: list[PurchaseOrderLineItem]
     id: int | Unset = UNSET
     message: None | str | Unset = UNSET
     order_date: datetime.datetime | None | Unset = UNSET
     created_date: datetime.datetime | None | Unset = UNSET
     fully_received_date: datetime.datetime | None | Unset = UNSET
+    supplier: None | PurchaseOrderSupplier | Unset = UNSET
     external_id: None | str | Unset = UNSET
     reference_number: None | str | Unset = UNSET
     client_reference_number: None | str | Unset = UNSET
     location: None | PurchaseOrderLocation | Unset = UNSET
     status: PurchaseOrderStatusDto | Unset = UNSET
+    purchase_order_line_items: list[PurchaseOrderLineItem] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.purchase_order_location import PurchaseOrderLocation
-
-        supplier = self.supplier.to_dict()
-
-        purchase_order_line_items = []
-        for purchase_order_line_items_item_data in self.purchase_order_line_items:
-            purchase_order_line_items_item = (
-                purchase_order_line_items_item_data.to_dict()
-            )
-            purchase_order_line_items.append(purchase_order_line_items_item)
+        from ..models.purchase_order_supplier import PurchaseOrderSupplier
 
         id = self.id
 
@@ -94,6 +86,14 @@ class PurchaseOrderResponseDto:
         else:
             fully_received_date = self.fully_received_date
 
+        supplier: dict[str, Any] | None | Unset
+        if isinstance(self.supplier, Unset):
+            supplier = UNSET
+        elif isinstance(self.supplier, PurchaseOrderSupplier):
+            supplier = self.supplier.to_dict()
+        else:
+            supplier = self.supplier
+
         external_id: None | str | Unset
         if isinstance(self.external_id, Unset):
             external_id = UNSET
@@ -124,14 +124,25 @@ class PurchaseOrderResponseDto:
         if not isinstance(self.status, Unset):
             status = self.status.value
 
+        purchase_order_line_items: list[dict[str, Any]] | None | Unset
+        if isinstance(self.purchase_order_line_items, Unset):
+            purchase_order_line_items = UNSET
+        elif isinstance(self.purchase_order_line_items, list):
+            purchase_order_line_items = []
+            for (
+                purchase_order_line_items_type_0_item_data
+            ) in self.purchase_order_line_items:
+                purchase_order_line_items_type_0_item = (
+                    purchase_order_line_items_type_0_item_data.to_dict()
+                )
+                purchase_order_line_items.append(purchase_order_line_items_type_0_item)
+
+        else:
+            purchase_order_line_items = self.purchase_order_line_items
+
         field_dict: dict[str, Any] = {}
 
-        field_dict.update(
-            {
-                "supplier": supplier,
-                "purchaseOrderLineItems": purchase_order_line_items,
-            }
-        )
+        field_dict.update({})
         if id is not UNSET:
             field_dict["id"] = id
         if message is not UNSET:
@@ -142,6 +153,8 @@ class PurchaseOrderResponseDto:
             field_dict["createdDate"] = created_date
         if fully_received_date is not UNSET:
             field_dict["fullyReceivedDate"] = fully_received_date
+        if supplier is not UNSET:
+            field_dict["supplier"] = supplier
         if external_id is not UNSET:
             field_dict["externalId"] = external_id
         if reference_number is not UNSET:
@@ -152,6 +165,8 @@ class PurchaseOrderResponseDto:
             field_dict["location"] = location
         if status is not UNSET:
             field_dict["status"] = status
+        if purchase_order_line_items is not UNSET:
+            field_dict["purchaseOrderLineItems"] = purchase_order_line_items
 
         return field_dict
 
@@ -162,17 +177,6 @@ class PurchaseOrderResponseDto:
         from ..models.purchase_order_supplier import PurchaseOrderSupplier
 
         d = dict(src_dict)
-        supplier = PurchaseOrderSupplier.from_dict(d.pop("supplier"))
-
-        purchase_order_line_items = []
-        _purchase_order_line_items = d.pop("purchaseOrderLineItems")
-        for purchase_order_line_items_item_data in _purchase_order_line_items:
-            purchase_order_line_items_item = PurchaseOrderLineItem.from_dict(
-                cast(Mapping[str, Any], purchase_order_line_items_item_data)
-            )
-
-            purchase_order_line_items.append(purchase_order_line_items_item)
-
         id = d.pop("id", UNSET)
 
         def _parse_message(data: object) -> None | str | Unset:
@@ -239,6 +243,25 @@ class PurchaseOrderResponseDto:
             d.pop("fullyReceivedDate", UNSET)
         )
 
+        def _parse_supplier(data: object) -> None | PurchaseOrderSupplier | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                supplier_type_1 = PurchaseOrderSupplier.from_dict(
+                    cast(Mapping[str, Any], data)
+                )
+
+                return supplier_type_1
+            except:  # noqa: E722
+                pass
+            return cast(None | PurchaseOrderSupplier | Unset, data)
+
+        supplier = _parse_supplier(d.pop("supplier", UNSET))
+
         def _parse_external_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -294,19 +317,56 @@ class PurchaseOrderResponseDto:
         else:
             status = PurchaseOrderStatusDto(_status)
 
+        def _parse_purchase_order_line_items(
+            data: object,
+        ) -> list[PurchaseOrderLineItem] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                purchase_order_line_items_type_0 = []
+                _purchase_order_line_items_type_0 = data
+                for (
+                    purchase_order_line_items_type_0_item_data
+                ) in _purchase_order_line_items_type_0:
+                    purchase_order_line_items_type_0_item = (
+                        PurchaseOrderLineItem.from_dict(
+                            cast(
+                                Mapping[str, Any],
+                                purchase_order_line_items_type_0_item_data,
+                            )
+                        )
+                    )
+
+                    purchase_order_line_items_type_0.append(
+                        purchase_order_line_items_type_0_item
+                    )
+
+                return purchase_order_line_items_type_0
+            except:  # noqa: E722
+                pass
+            return cast(list[PurchaseOrderLineItem] | None | Unset, data)
+
+        purchase_order_line_items = _parse_purchase_order_line_items(
+            d.pop("purchaseOrderLineItems", UNSET)
+        )
+
         purchase_order_response_dto = cls(
-            supplier=supplier,
-            purchase_order_line_items=purchase_order_line_items,
             id=id,
             message=message,
             order_date=order_date,
             created_date=created_date,
             fully_received_date=fully_received_date,
+            supplier=supplier,
             external_id=external_id,
             reference_number=reference_number,
             client_reference_number=client_reference_number,
             location=location,
             status=status,
+            purchase_order_line_items=purchase_order_line_items,
         )
 
         return purchase_order_response_dto

--- a/tests/test_helpers_purchase_orders.py
+++ b/tests/test_helpers_purchase_orders.py
@@ -4,6 +4,9 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from stocktrim_public_api_client.generated.models.purchase_order_response_dto import (
+    PurchaseOrderResponseDto,
+)
 from stocktrim_public_api_client.helpers.purchase_orders import PurchaseOrders
 
 
@@ -46,3 +49,28 @@ async def test_find_by_reference_returns_none_on_404(monkeypatch):
     result = await purchase_orders.find_by_reference("MISSING-PO")
 
     assert result is None
+
+
+def test_get_purchase_order_handles_null_supplier_and_line_items():
+    """Regression for issue #214.
+
+    StockTrim's API has been observed returning purchase orders with both
+    ``supplier`` and ``purchaseOrderLineItems`` set to ``null`` (reproducer:
+    audit log 2026-05-27, PO-01066). The OpenAPI spec documents these as
+    required + non-nullable, so the generated ``PurchaseOrderResponseDto``
+    previously crashed in ``from_dict`` when trying to call
+    ``PurchaseOrderSupplier.from_dict(None)`` and iterate ``None``. Both
+    fields must now parse without raising and round-trip to ``None``."""
+    payload = {
+        "id": 1066,
+        "referenceNumber": "PO-01066",
+        "supplier": None,
+        "purchaseOrderLineItems": None,
+    }
+
+    dto = PurchaseOrderResponseDto.from_dict(payload)
+
+    assert dto.id == 1066
+    assert dto.reference_number == "PO-01066"
+    assert dto.supplier is None
+    assert dto.purchase_order_line_items is None


### PR DESCRIPTION
## Summary

Closes #214. See also #215 (broader audit of scalar required-but-nullable fields).

StockTrim's API was observed (audit log 2026-05-27, PO-01066) returning
purchase orders with both `supplier` and `purchaseOrderLineItems` set
to `null`. The OpenAPI spec documents these as `required` and
non-nullable, so the generated `PurchaseOrderResponseDto.from_dict`
crashed when it tried to call `PurchaseOrderSupplier.from_dict(None)`
and iterate `None` for line items.

This PR extends the existing nullable-field patch pipeline (same shape
as #202 used for `SupplierResponseDto.supplierCode`) to cover four
(DTO, field) pairs:

| Schema | Field |
| --- | --- |
| `PurchaseOrderResponseDto` | `supplier` |
| `PurchaseOrderResponseDto` | `purchaseOrderLineItems` |
| `PurchaseOrderRequestDto` | `supplier` |
| `PurchaseOrderRequestDto` | `purchaseOrderLineItems` |

The Request DTO is included because several POST endpoints echo the
request body in their responses; fixing both now keeps the door
permanently closed.

### Changes

- `scripts/regenerate_client.py` — extend `NULLABLE_FIELDS` with the 4 new entries.
- `stocktrim-openapi.yaml` — drop the fields from each schema's `required:` and mark them nullable (`supplier` uses the `allOf` wrapper pattern because OpenAPI 3.0 ignores `nullable: true` next to `$ref`).
- Regenerated `purchase_order_response_dto.py` and `purchase_order_request_dto.py`. Consumer code in `helpers/` and the MCP server already gates `.supplier` and `.purchase_order_line_items` access with `if po.supplier:` / `if po.purchase_order_line_items:` style checks, so no downstream changes were needed.
- New regression test in `tests/test_helpers_purchase_orders.py` that feeds `{supplier: None, purchaseOrderLineItems: None}` to `from_dict` and asserts both round-trip to `None`.

### Coordination with other open PRs

- #211 (Unpack Strategy C) and #213 (rebase-before-PR CRITICAL) are unrelated and stay open. Both will need a trivial rebase when this merges.
- Per the eat-our-own-dogfood pattern from #213, this branch was fetched + checked against `origin/main` before pushing.

## Test plan

- [x] `uv run poe check` — 97 client tests + 352 MCP tests pass, ruff/ty/yamllint clean
- [x] New `test_get_purchase_order_handles_null_supplier_and_line_items` regression test asserts parsing succeeds when both fields are `null`
- [x] Pre-commit hooks pass (no `--no-verify`)
- [x] Generated diff confirmed touching only the 2 target files
- [ ] Reviewer: confirm no surprise downstream breakage with `po.supplier` / `po.purchase_order_line_items` truthiness gates

## Spec drift note

The generator now (openapi-python-client) emits `except (TypeError, ValueError, AttributeError, KeyError):` instead of the older `except:  # noqa: E722` style still present elsewhere in `generated/models/`. To keep this PR's diff focused, I normalized the two regenerated files back to the in-repo `except:  # noqa: E722` style. A future full regen will need to either re-do the same normalization for every model or update the repo style to match the new generator output — worth a separate decision, not a blocker here.