### PR TITLE
chore(client): narrow bare except in generated/ parsers (closes #217)

### DIFF
--- a/stocktrim_public_api_client/generated/models/order_plan_filter_criteria.py
+++ b/stocktrim_public_api_client/generated/models/order_plan_filter_criteria.py
@@ -185,7 +185,7 @@ class OrderPlanFilterCriteria:
                 current_status_type_1 = CurrentStatusEnum(data)
 
                 return current_status_type_1
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(CurrentStatusEnum | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/order_plan_filter_criteria_dto.py
+++ b/stocktrim_public_api_client/generated/models/order_plan_filter_criteria_dto.py
@@ -100,7 +100,7 @@ class OrderPlanFilterCriteriaDto:
                 location_codes_type_0 = cast(list[str], data)
 
                 return location_codes_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[str] | None | Unset, data)
 
@@ -117,7 +117,7 @@ class OrderPlanFilterCriteriaDto:
                 supplier_codes_type_0 = cast(list[str], data)
 
                 return supplier_codes_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[str] | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/order_plan_results_dto.py
+++ b/stocktrim_public_api_client/generated/models/order_plan_results_dto.py
@@ -78,7 +78,7 @@ class OrderPlanResultsDto:
                     results_type_0.append(results_type_0_item)
 
                 return results_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[SkuOptimizedResultsDto] | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/products_request_dto.py
+++ b/stocktrim_public_api_client/generated/models/products_request_dto.py
@@ -536,7 +536,7 @@ class ProductsRequestDto:
                     suppliers_type_0.append(suppliers_type_0_item)
 
                 return suppliers_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[ProductSupplier] | None | Unset, data)
 
@@ -707,7 +707,7 @@ class ProductsRequestDto:
                     stock_locations_type_0.append(stock_locations_type_0_item)
 
                 return stock_locations_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[ProductLocation] | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/products_response_dto.py
+++ b/stocktrim_public_api_client/generated/models/products_response_dto.py
@@ -544,7 +544,7 @@ class ProductsResponseDto:
                     suppliers_type_0.append(suppliers_type_0_item)
 
                 return suppliers_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[ProductSupplier] | None | Unset, data)
 
@@ -715,7 +715,7 @@ class ProductsResponseDto:
                     stock_locations_type_0.append(stock_locations_type_0_item)
 
                 return stock_locations_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[ProductLocation] | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/purchase_order_line_item.py
+++ b/stocktrim_public_api_client/generated/models/purchase_order_line_item.py
@@ -79,7 +79,7 @@ class PurchaseOrderLineItem:
                 received_date_type_0 = isoparse(data)
 
                 return received_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/purchase_order_request_dto.py
+++ b/stocktrim_public_api_client/generated/models/purchase_order_request_dto.py
@@ -168,7 +168,7 @@ class PurchaseOrderRequestDto:
                 order_date_type_0 = isoparse(data)
 
                 return order_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -185,7 +185,7 @@ class PurchaseOrderRequestDto:
                 created_date_type_0 = isoparse(data)
 
                 return created_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -204,7 +204,7 @@ class PurchaseOrderRequestDto:
                 fully_received_date_type_0 = isoparse(data)
 
                 return fully_received_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -254,7 +254,7 @@ class PurchaseOrderRequestDto:
                 )
 
                 return location_type_1
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(None | PurchaseOrderLocation | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/purchase_order_response_dto.py
+++ b/stocktrim_public_api_client/generated/models/purchase_order_response_dto.py
@@ -195,7 +195,7 @@ class PurchaseOrderResponseDto:
                 order_date_type_0 = isoparse(data)
 
                 return order_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -212,7 +212,7 @@ class PurchaseOrderResponseDto:
                 created_date_type_0 = isoparse(data)
 
                 return created_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -231,7 +231,7 @@ class PurchaseOrderResponseDto:
                 fully_received_date_type_0 = isoparse(data)
 
                 return fully_received_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -281,7 +281,7 @@ class PurchaseOrderResponseDto:
                 )
 
                 return location_type_1
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(None | PurchaseOrderLocation | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/sales_order_with_line_items_request_dto.py
+++ b/stocktrim_public_api_client/generated/models/sales_order_with_line_items_request_dto.py
@@ -163,7 +163,7 @@ class SalesOrderWithLineItemsRequestDto:
                     )
 
                 return sale_order_line_items_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[SalesOrderRequestDto] | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/set_inventory_request.py
+++ b/stocktrim_public_api_client/generated/models/set_inventory_request.py
@@ -95,7 +95,7 @@ class SetInventoryRequest:
                     inventory_type_0.append(inventory_type_0_item)
 
                 return inventory_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[Inventory] | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/sku_optimized_results_dto.py
+++ b/stocktrim_public_api_client/generated/models/sku_optimized_results_dto.py
@@ -908,7 +908,7 @@ class SkuOptimizedResultsDto:
                 tenant_id_type_0 = UUID(data)
 
                 return tenant_id_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(None | Unset | UUID, data)
 
@@ -934,7 +934,7 @@ class SkuOptimizedResultsDto:
                 effective_to_date_time_type_0 = isoparse(data)
 
                 return effective_to_date_time_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -1059,7 +1059,7 @@ class SkuOptimizedResultsDto:
                 latest_order_date_type_0 = isoparse(data)
 
                 return latest_order_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 
@@ -1078,7 +1078,7 @@ class SkuOptimizedResultsDto:
                 first_purchase_date_type_0 = isoparse(data)
 
                 return first_purchase_date_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(datetime.datetime | None | Unset, data)
 

--- a/stocktrim_public_api_client/generated/models/square_web_hook_object.py
+++ b/stocktrim_public_api_client/generated/models/square_web_hook_object.py
@@ -123,7 +123,7 @@ class SquareWebHookObject:
                     inventory_counts_type_0.append(inventory_counts_type_0_item)
 
                 return inventory_counts_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(list[InventoryCountWebHook] | None | Unset, data)
 


### PR DESCRIPTION
## Summary

Replace 24 bare `except:  # noqa: E722` blocks with the narrow `except (TypeError, ValueError, AttributeError, KeyError):` form across 12 generated model files in `stocktrim_public_api_client/generated/models/`.

Modern `openapi-python-client` (0.28.1, our resolved version) already emits this narrow form in its Jinja templates — our sites were stale artifacts from an older generator. This sweep closes the gap so future regens stay clean without any post-processing or noqa tolerance.

Closes #217.

## Why this matters

- Bare `except:` swallows `SystemExit` / `KeyboardInterrupt` / `GeneratorExit`. The narrow tuple catches exactly what the `_parse_*` helpers can actually raise.
- `# noqa: E722` violates CLAUDE.md's zero-tolerance policy. Tolerating it in `generated/` only made sense while the gap with the generator existed — it no longer does.
- Every full regeneration with the current generator naturally produces the narrow form, so this sweep + clean future regens with no special handling.

## Behavior change

None. The narrow tuple is a strict subset of what bare `except` was catching, and it covers every exception the parser code is capable of raising (TypeError from explicit raises and typing checks, ValueError from enum/date parsing, AttributeError/KeyError from defensive access).

## Acceptance criteria

- [x] `grep -r 'noqa: E722' stocktrim_public_api_client/generated/` returns 0 matches
- [x] `grep -rcE 'except \(TypeError, ValueError, AttributeError, KeyError\):' stocktrim_public_api_client/generated/models/` sums to 24 across 12 files
- [x] `uv run poe check` passes (96 client tests + 352 MCP tests, lint, type-check)
- [x] No changes to non-generated files

## Test plan

- [x] `uv run poe check` green locally
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)