### PR TITLE
chore(harness): codify full-regen policy + deferral protocol

### DIFF
--- a/.claude/skills/add-nullable-field/SKILL.md
+++ b/.claude/skills/add-nullable-field/SKILL.md
@@ -13,17 +13,22 @@ Patch `NULLABLE_FIELDS` in the regeneration script, regenerate, validate, and do
 
 ## PURPOSE
 
-Make a generated model field nullable so the client stops crashing on null API responses — without adding `# type: ignore`.
+Make a generated model field nullable so the client stops crashing on null API responses
+— without adding `# type: ignore`.
 
 ## CRITICAL
 
-- **Never use `# type: ignore` to silence the error** — that's a forbidden shortcut per CLAUDE.md. Add the field to `NULLABLE_FIELDS` and regenerate.
-- **Never edit `stocktrim_public_api_client/generated/` directly** — changes are lost on regeneration.
-- **The fix must be reproducible from the spec** — anyone running `uv run poe regenerate-client` must get the same result.
+- **Never use `# type: ignore` to silence the error** — that's a forbidden shortcut per
+  CLAUDE.md. Add the field to `NULLABLE_FIELDS` and regenerate.
+- **Never edit `stocktrim_public_api_client/generated/` directly** — changes are lost on
+  regeneration.
+- **The fix must be reproducible from the spec** — anyone running
+  `uv run poe regenerate-client` must get the same result.
 
 ## ASSUMES
 
-- You have an actual error message identifying the schema and field (e.g., `PurchaseOrderResponseDto.orderDate` returns null but spec marks it required).
+- You have an actual error message identifying the schema and field (e.g.,
+  `PurchaseOrderResponseDto.orderDate` returns null but spec marks it required).
 - `scripts/regenerate_client.py` exists and contains a `NULLABLE_FIELDS` dict.
 
 ## STANDARD PATH
@@ -53,7 +58,8 @@ NULLABLE_FIELDS = {
 }
 ```
 
-Use the same comment style as existing entries. Mark with `⚠️ CRITICAL` if null actually crashes (not just wrong types).
+Use the same comment style as existing entries. Mark with `⚠️ CRITICAL` if null actually
+crashes (not just wrong types).
 
 ### 3. Regenerate
 
@@ -67,30 +73,53 @@ uv run poe regenerate-client
 uv run poe check
 ```
 
-ALL must pass. If a different field is now broken, repeat from step 1 — don't bail with `# type: ignore`.
+ALL must pass. If a different field is now broken, repeat from step 1 — don't bail with
+`# type: ignore`.
 
-### 5. Confirm the diff is bounded
+### 5. Inspect the diff and absorb any upstream drift
 
 ```bash
 git diff --stat
 ```
 
-You should see:
+You'll see at minimum:
 
 - `scripts/regenerate_client.py` (1 small change)
-- `stocktrim_public_api_client/generated/models/<schema>.py` (the field becomes `Optional`)
+- `stocktrim_public_api_client/generated/models/<schema>.py` (the field becomes
+  `Optional`)
 - Possibly `client_types.py` if reexports change
 
-If the diff is much bigger, regeneration picked up an unrelated upstream change. Stash, run regeneration on a clean baseline, then re-apply your `NULLABLE_FIELDS` change.
+**If the diff is bigger than that, it's because the live StockTrim spec drifted since
+the last regen — this is expected and good.** The regen pulls the latest spec; **default
+is to absorb that drift in the same PR as additional commits.** Adapt downstream code
+(helpers, services, tests, MCP tools) to match any new field shapes, renames, or
+removals. Document the broader changes in the commit body so reviewers see what changed
+in the API surface.
+
+If the drift introduces sprawling adaptations that would meaningfully delay your
+nullable-field fix and absolutely cannot ride along, follow the **deferral protocol** in
+`.claude/skills/regenerate-client/SKILL.md` (file `tech-debt` tracking issue + open the
+regen PR next + reference from this PR's description). Deferring without those three
+steps is the anti-pattern that caused the 2026-05 drift bugs.
+
+**DO NOT** stash, reset, or otherwise try to suppress the drift to keep the diff small.
+Surgical regens that only touch 1–2 files are an **anti-pattern**; they bypass the live
+spec download and leave the rest of `generated/` frozen against an old generator.
 
 ### 6. Document evidence (optional)
 
-If `docs/contributing/api-feedback.md` exists, append a row noting the schema + field + observed behavior. This is the canonical record for "spec says required, API returns null."
+If `docs/contributing/api-feedback.md` exists, append a row noting the schema + field +
+observed behavior. This is the canonical record for "spec says required, API returns
+null."
 
 ## EDGE CASES
 
-- [Field is in a deeply nested array item] — `NULLABLE_FIELDS` works at the top level of a schema. For nested types, check whether the nested schema is itself a top-level component (it usually is) and add it there.
-- [Field is required in some endpoints but not others] — `NULLABLE_FIELDS` marks the schema field nullable everywhere it's used. Acceptable trade-off; document in the comment.
+- [Field is in a deeply nested array item] — `NULLABLE_FIELDS` works at the top level of
+  a schema. For nested types, check whether the nested schema is itself a top-level
+  component (it usually is) and add it there.
+- [Field is required in some endpoints but not others] — `NULLABLE_FIELDS` marks the
+  schema field nullable everywhere it's used. Acceptable trade-off; document in the
+  comment.
 
 ## RELATED
 

--- a/.claude/skills/regenerate-client/SKILL.md
+++ b/.claude/skills/regenerate-client/SKILL.md
@@ -10,23 +10,44 @@ allowed-tools: Bash(uv run poe regenerate-client), Bash(uv run poe check), Bash(
 
 # /regenerate-client — Regenerate the StockTrim API Client
 
-Run the OpenAPI regeneration pipeline, validate, and commit the result on a feature branch.
+Run the OpenAPI regeneration pipeline, validate, and commit the result on a feature
+branch.
 
 ## PURPOSE
 
-Replace the generated client with a fresh build from the live spec, with all post-processing applied.
+Replace the generated client with a fresh build from the live spec, with all
+post-processing applied.
 
 ## CRITICAL
 
-- **Never hand-edit `stocktrim_public_api_client/generated/` or `client_types.py`** — both are wholly replaced by this skill. Edits are silently lost.
-- **All type/null fixes go in `scripts/regenerate_client.py`** — never add `# type: ignore` to generated code; add the field to `NULLABLE_FIELDS` instead.
+- **ALWAYS use the full pipeline (`uv run poe regenerate-client`).** Surgical regens —
+  manually running `openapi-python-client generate` against the cached spec and copying
+  1–2 files into `generated/` — are an **ANTI-PATTERN**. They bypass the live spec
+  download, leave the rest of `generated/` frozen against the older generator, and
+  accumulate drift bugs (stale field types, bare-except patterns, missing nullable
+  markers). If you need to regenerate ANYTHING, regenerate EVERYTHING.
+- **Default: absorb upstream drift in the same PR as additional commits.** Keep the
+  immediate-fix commit focused, then add follow-up commits adapting
+  helpers/services/tests for whatever the regen brought in. Do not stash or reset to
+  keep the diff small.
+- **Deferral protocol (only when you absolutely cannot ship the regen in the same PR):**
+  ALL of the following are mandatory:
+  1. File a `tech-debt` tracking issue noting the regen is owed and why it was deferred.
+  1. Open the regen PR as the very next piece of work — no unrelated tasks first.
+  1. Reference the tracking issue from the deferring PR's description.
+- **Never hand-edit `stocktrim_public_api_client/generated/` or `client_types.py`** —
+  both are wholly replaced by this skill. Edits are silently lost.
+- **All type/null fixes go in `scripts/regenerate_client.py`** — never add
+  `# type: ignore` to generated code; add the field to `NULLABLE_FIELDS` instead.
 - **Must be on a feature branch** — never regenerate directly on `main`.
-- **CLAUDE.md zero-tolerance applies** — `uv run poe check` must be green before committing.
+- **CLAUDE.md zero-tolerance applies** — `uv run poe check` must be green before
+  committing.
 
 ## ASSUMES
 
 - You're in a git repository on a feature branch (or willing to create one).
-- The live StockTrim spec at `https://api.stocktrim.com/swagger/v1/swagger.yaml` is reachable.
+- The live StockTrim spec at `https://api.stocktrim.com/swagger/v1/swagger.yaml` is
+  reachable.
 - `uv` and project deps are installed (`uv sync`).
 
 ## STANDARD PATH
@@ -49,14 +70,14 @@ uv run poe regenerate-client
 This invokes `scripts/regenerate_client.py` which:
 
 1. Downloads the spec
-2. Patches auth (header params → securitySchemes)
-3. Validates with `openapi-spec-validator` and Redocly
-4. Generates the client via `openapi-python-client`
-5. Renames `types.py` → `client_types.py` and rewrites imports
-6. Modernizes `Union[X, Y]` → `X | Y`
-7. Fixes RST docstrings
-8. Applies `NULLABLE_FIELDS` overrides
-9. Runs `ruff --fix`
+1. Patches auth (header params → securitySchemes)
+1. Validates with `openapi-spec-validator` and Redocly
+1. Generates the client via `openapi-python-client`
+1. Renames `types.py` → `client_types.py` and rewrites imports
+1. Modernizes `Union[X, Y]` → `X | Y`
+1. Fixes RST docstrings
+1. Applies `NULLABLE_FIELDS` overrides
+1. Runs `ruff --fix`
 
 ### 3. Inspect the diff
 
@@ -75,9 +96,12 @@ uv run poe check
 
 ALL must pass. If failures appear:
 
-- **Type error on null field?** → Add to `NULLABLE_FIELDS` in `scripts/regenerate_client.py`, re-run from Step 2. Never add `# type: ignore`.
-- **Helper method broken by renamed model?** → Update the helper. Helpers wrap generated/, so they need to track renames.
-- **MCP tool broken?** → Update the corresponding service in `stocktrim_mcp_server/src/.../services/`.
+- **Type error on null field?** → Add to `NULLABLE_FIELDS` in
+  `scripts/regenerate_client.py`, re-run from Step 2. Never add `# type: ignore`.
+- **Helper method broken by renamed model?** → Update the helper. Helpers wrap
+  generated/, so they need to track renames.
+- **MCP tool broken?** → Update the corresponding service in
+  `stocktrim_mcp_server/src/.../services/`.
 
 ### 5. Commit on feature branch
 
@@ -95,17 +119,22 @@ EOF
 )"
 ```
 
-Use `feat(client):` scope for client release; add `chore(mcp):` companion commit if MCP services were updated.
+Use `feat(client):` scope for client release; add `chore(mcp):` companion commit if MCP
+services were updated.
 
 ## EDGE CASES
 
-- [Spec download fails] — Check `SPEC_URL` in `scripts/regenerate_client.py`. Network issue? Retry. Permanent? Open an issue.
+- [Spec download fails] — Check `SPEC_URL` in `scripts/regenerate_client.py`. Network
+  issue? Retry. Permanent? Open an issue.
 - [Generation breaks for an unrelated schema] — Read DETAIL: Quarantining a Schema
-- [Helper or test fails after regen] — Update the helper/test. Generated code is the source of truth; downstream code adapts.
+- [Helper or test fails after regen] — Update the helper/test. Generated code is the
+  source of truth; downstream code adapts.
 
 ## DETAIL: Quarantining a Schema
 
-If a schema generates uncompilable code (rare), patch it in `scripts/regenerate_client.py` before the generation step rather than editing the generated output.
+If a schema generates uncompilable code (rare), patch it in
+`scripts/regenerate_client.py` before the generation step rather than editing the
+generated output.
 
 ## RELATED
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,8 @@ uv run poe test-mcp              # Run MCP server tests (stocktrim_mcp_server/te
 uv run poe test-coverage         # Run tests with coverage reports (HTML, terminal, XML)
 ```
 
-`uv run poe check` runs both `test` and `test-mcp`, so the MCP server suite cannot regress silently when only the client lib is touched.
+`uv run poe check` runs both `test` and `test-mcp`, so the MCP server suite cannot
+regress silently when only the client lib is touched.
 
 ### Documentation
 
@@ -180,6 +181,8 @@ this format for consistency.
 - Call real APIs in tests
 - Leave debug code or commented sections
 - Ignore pre-existing test failures or linting errors
+- **Surgical regens** — manually running `openapi-python-client generate` and copying
+  1–2 files into `generated/`
 
 ✅ **Do this instead:**
 
@@ -189,39 +192,79 @@ this format for consistency.
 - Mock all external dependencies
 - Remove all debug code before PR
 - Fix ALL tests and linting issues, regardless of when they were introduced
+- **Always run the full regeneration pipeline (`uv run poe regenerate-client`)** when
+  touching `generated/`. Absorb the upstream spec drift in the same PR.
+
+## Client regeneration policy
+
+The StockTrim OpenAPI spec evolves continuously. **Always pull the latest spec and adapt
+downstream code as necessary.**
+
+- **Default path**: `uv run poe regenerate-client` (downloads latest spec → patches →
+  regenerates everything → ruff post-processing).
+
+- **Surgical regens** (manually running `openapi-python-client generate` on a cached
+  spec and copying individual files) are an **ANTI-PATTERN**. They bypass the spec
+  download, leave the rest of `generated/` stale against the modern generator, and
+  accumulate invisible drift bugs (stale field types, bare-except patterns, missing
+  nullable markers, etc.).
+
+- **Drift compounds.** Six months of deferred regens caused multiple production bugs in
+  2026-05 (null `supplierCode`, null `purchaseOrderLineItems`/`supplier`, bare-except
+  parser patterns). All would have been caught by routine full regens.
+
+- **Embrace the diff.** When a full regen pulls in changes beyond your immediate fix,
+  the **default is to ship the broader adaptations in the same PR** as additional
+  commits — keep the immediate-fix commit focused, then add follow-up commits adapting
+  helpers/services/tests to absorb the drift.
+
+- **Deferral protocol.** If absorbing the full regen genuinely cannot ride in the same
+  PR (e.g. the immediate fix is urgent and the drift introduces sprawling adaptations
+  that would block it), then ALL THREE of the following are mandatory:
+
+  1. **File a tracking issue** (labelled `tech-debt`) noting that a regen is owed, with
+     the specific reason it was deferred.
+  1. **Open the regen PR as the very next piece of work** — do not start unrelated tasks
+     first. The drift doesn't sit on the shelf.
+  1. **Reference the tracking issue from the immediate-fix PR description** so reviewers
+     and future-you see the debt explicitly.
+
+  Deferring without these three steps is the same anti-pattern that caused the 2026-05
+  bugs. Don't.
+
+See `.claude/skills/regenerate-client/SKILL.md` for the full procedure.
 
 ## Agent Harness
 
-This repo uses the [harness-kit](https://github.com/dougborg/harness-kit) plugin
-for Claude Code, with project-specific extensions in `.claude/`. Provenance is
-tracked in `.harness-lock.json`. Run `/harness-kit:harness` to audit, update, or
-retro the harness.
+This repo uses the [harness-kit](https://github.com/dougborg/harness-kit) plugin for
+Claude Code, with project-specific extensions in `.claude/`. Provenance is tracked in
+`.harness-lock.json`. Run `/harness-kit:harness` to audit, update, or retro the harness.
 
 ### Skills
 
-| Skill | Purpose |
-| --- | --- |
-| `/commit` | Quality-gated conventional commits (upstream) |
-| `/feature-spec` | Spec before multi-file implementations (upstream) |
-| `/open-pr` | Push, create PR, wait for CI, address first round (upstream) |
-| `/code-reviewer` | Six-dimension review with project-specific BLOCKING rules |
-| `/skill-writer` | Author new skills with progressive disclosure (upstream) |
-| `/standup` | Git/GitHub activity recap (upstream) |
-| `/regenerate-client` | Run the OpenAPI regeneration pipeline + commit |
+| Skill                 | Purpose                                                      |
+| --------------------- | ------------------------------------------------------------ |
+| `/commit`             | Quality-gated conventional commits (upstream)                |
+| `/feature-spec`       | Spec before multi-file implementations (upstream)            |
+| `/open-pr`            | Push, create PR, wait for CI, address first round (upstream) |
+| `/code-reviewer`      | Six-dimension review with project-specific BLOCKING rules    |
+| `/skill-writer`       | Author new skills with progressive disclosure (upstream)     |
+| `/standup`            | Git/GitHub activity recap (upstream)                         |
+| `/regenerate-client`  | Run the OpenAPI regeneration pipeline + commit               |
 | `/add-nullable-field` | Patch `NULLABLE_FIELDS` and regenerate (no `# type: ignore`) |
-| `/add-helper-method` | Add a typed helper that wraps a generated call |
-| `/add-mcp-tool` | Add an MCP tool + service + test |
-| `/quality-gate` | CLAUDE.md zero-tolerance pre-done checklist |
+| `/add-helper-method`  | Add a typed helper that wraps a generated call               |
+| `/add-mcp-tool`       | Add an MCP tool + service + test                             |
+| `/quality-gate`       | CLAUDE.md zero-tolerance pre-done checklist                  |
 
 ### Agents
 
-| Agent | Purpose | Model |
-| --- | --- | --- |
-| `code-reviewer` | Pre-PR review (6 dimensions + StockTrim-specific blockers) | sonnet |
-| `verifier` | Final-gate check: validation, branch, no shortcuts | haiku |
-| `test-writer` | Pytest tests with httpx transport mocks | sonnet |
-| `domain-advisor` | Read-only Q&A on StockTrim API quirks, retry policy, auth | sonnet |
-| `project-manager` | GitHub issues, PRs, releases, dependabot triage | sonnet |
+| Agent             | Purpose                                                    | Model  |
+| ----------------- | ---------------------------------------------------------- | ------ |
+| `code-reviewer`   | Pre-PR review (6 dimensions + StockTrim-specific blockers) | sonnet |
+| `verifier`        | Final-gate check: validation, branch, no shortcuts         | haiku  |
+| `test-writer`     | Pytest tests with httpx transport mocks                    | sonnet |
+| `domain-advisor`  | Read-only Q&A on StockTrim API quirks, retry policy, auth  | sonnet |
+| `project-manager` | GitHub issues, PRs, releases, dependabot triage            | sonnet |
 
 ### Automation Philosophy
 
@@ -229,11 +272,10 @@ retro the harness.
 
 1. **Formatters** (silent, zero-token) — `ruff check --fix` and `ruff format` run
    automatically on every Python edit so style issues never reach Claude.
-2. **Validators** (bounded, gated) — `ty check` and per-file `pytest` run on the
-   touched file only; output is capped at ≤25 lines so noise never drowns signal.
-3. **Guidance** (≤20 lines) — generated/ edits, regenerate_client.py changes,
-   and OpenAPI spec touches print a one-line nudge pointing to the right skill.
+1. **Validators** (bounded, gated) — `ty check` and per-file `pytest` run on the touched
+   file only; output is capped at ≤25 lines so noise never drowns signal.
+1. **Guidance** (≤20 lines) — generated/ edits, regenerate_client.py changes, and
+   OpenAPI spec touches print a one-line nudge pointing to the right skill.
 
-A Stop hook nudges toward `/harness-kit:harness retro` after sessions touching
-more than three files. Never silence these by removing them — fix the cause they
-surface.
+A Stop hook nudges toward `/harness-kit:harness retro` after sessions touching more than
+three files. Never silence these by removing them — fix the cause they surface.


### PR DESCRIPTION
## Summary

The 2026-05-26 audit + the full regen run today (PR #219, -1197 net lines, 8 models removed, 9 obsolete NULLABLE_FIELDS pruned, PR #218 fully obsoleted) demonstrated that deferring regens accumulates invisible drift and bugs. This PR encodes the lesson into the harness so the next agent (or future Claude) defaults to the right thing.

## What changed

### \`CLAUDE.md\`
- New "Client regeneration policy" section: full pipeline is the default; surgical regens are explicitly listed as an anti-pattern; the deferral protocol is spelled out.
- "Common Pitfalls" updated: surgical regens added to the ❌ list, full pipeline to the ✅ list.

### \`.claude/skills/regenerate-client/SKILL.md\`
- CRITICAL section expanded: full pipeline is mandatory; deferral protocol (tracking issue + immediate regen PR + cross-reference) listed as the only acceptable way to ship a fix without absorbing the drift.

### \`.claude/skills/add-nullable-field/SKILL.md\`
- Step 5 ("Confirm the diff is bounded") flipped: was telling you to **stash + re-run on a clean baseline + reapply** to keep the diff bounded — that's exactly the suppress-drift anti-pattern that caused the bugs. Now reads as **absorb the drift; if you absolutely can't, follow the deferral protocol.**

## Why now

PR #219's results validated the user's policy decision empirically:
- 9 manually-maintained NULLABLE_FIELDS entries became redundant (upstream now natively nullable).
- 24 bare-except parser patterns disappeared for free (modern generator emits narrow tuples).
- PR #218's narrow-except sweep is fully obsoleted by the regen; PR #216's PO null-field fix collapses to a near-no-op.

Six months of surgical-regen drift caused all of these. The policy change makes the maintenance-cost case explicit: keep current continuously, absorb each spec change in small batches, instead of paying a once-yearly mega-merge in pain.

## Test plan

- [x] \`uv run poe lint\` clean
- [x] \`mdformat\` auto-formatted the markdown additions (its hook ran, files were re-staged)
- [x] Policy text is self-consistent across all three surfaces
- [ ] Future agents who touch \`generated/\` follow the policy (validation comes from PR review on PRs that touch generated/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)