### PR TITLE
feat(assemblies): reconcile buy-it-whole assemblies as purchased

### DIFF
--- a/scripts/reconcile_purchased_assemblies.py
+++ b/scripts/reconcile_purchased_assemblies.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Reconcile buy-it-whole assemblies (e.g. bike frames) as purchased in StockTrim.
+
+Katana syncs multi-level BOMs (complete bike -> frame -> frame parts) into
+StockTrim, which then explodes every level and generates purchase demand for the
+deepest components. For assemblies we buy whole (frames), we want explosion to
+stop at the assembly: keep its demand (it still rolls up from the parent BOM) and
+order it directly, but not order its sub-parts.
+
+This script strips each detected assembly's own sub-BOM (leaving the parent ->
+assembly link intact) and then triggers a forecast recalculation, which
+supersedes the auto-recalc StockTrim runs immediately after a Katana import.
+
+It is idempotent and intended to run on a schedule whose cadence covers the
+Katana import frequency.
+
+Credentials come from the environment (STOCKTRIM_API_AUTH_ID /
+STOCKTRIM_API_AUTH_SIGNATURE), as with the other scripts in this directory.
+
+Usage:
+    uv run python scripts/reconcile_purchased_assemblies.py [--dry-run]
+        [--no-expand-variants] [--no-forecast] [FINISHED_GOOD_ID ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+from stocktrim_public_api_client import StockTrimClient
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "finished_good_ids",
+        nargs="*",
+        help="Finished-good product IDs to seed from. Defaults to auto-detected "
+        "BOM roots.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without deleting BOMs or recalculating.",
+    )
+    parser.add_argument(
+        "--no-expand-variants",
+        action="store_true",
+        help="Do not expand detected assemblies to sibling variants by parent_id.",
+    )
+    parser.add_argument(
+        "--no-forecast",
+        action="store_true",
+        help="Do not trigger a forecast recalculation after stripping sub-BOMs.",
+    )
+    return parser.parse_args()
+
+
+async def main() -> None:
+    args = _parse_args()
+    seed_ids = args.finished_good_ids or None
+
+    async with StockTrimClient() as client:
+        assemblies = client.assemblies
+
+        if args.dry_run:
+            finished_goods = seed_ids or await assemblies.detect_finished_goods()
+            detected = await assemblies.detect_purchased_assemblies(finished_goods)
+            logger.info("Finished goods (roots): %d", len(finished_goods))
+            logger.info("Intermediate assemblies detected: %s", detected or "none")
+            logger.info("Dry run — no BOMs deleted, no recalculation triggered.")
+            return
+
+        summary = await assemblies.reconcile_purchased_assemblies(
+            finished_good_ids=seed_ids,
+            expand_variants=not args.no_expand_variants,
+            run_forecast=not args.no_forecast,
+        )
+
+    logger.info("Detected assemblies: %s", summary.detected or "none")
+    for result in summary.changed:
+        logger.info(
+            "  %s -> removed %d sub-BOM rows: %s",
+            result.product_id,
+            len(result.removed_components),
+            result.removed_components,
+        )
+    logger.info(
+        "Done: %d assemblies changed, %d sub-BOM rows removed.",
+        len(summary.changed),
+        summary.total_removed,
+    )
+    if not args.no_forecast and summary.changed:
+        logger.info("Forecast recalculation triggered.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/stocktrim_public_api_client/helpers/assemblies.py
+++ b/stocktrim_public_api_client/helpers/assemblies.py
@@ -22,7 +22,6 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 
 from stocktrim_public_api_client.helpers.base import Base
-from stocktrim_public_api_client.helpers.products import is_variant_match
 from stocktrim_public_api_client.utils import unwrap_unset
 
 
@@ -117,8 +116,13 @@ class Assemblies(Base):
         Walks the BOM tree below each finished good (to any depth) and returns
         every descendant that is itself a BOM parent — i.e. has its own sub-BOM.
         These are the "buy-it-whole" assemblies (e.g. frames) whose sub-BOM
-        should be stripped. The finished goods themselves are never returned, so
-        their top-level BOM (e.g. bike -> frame) is preserved. Cycle-safe.
+        should be stripped.
+
+        The ``finished_good_ids`` are traversal seeds, not results: a seed is
+        returned only if it reappears as a descendant of another node, which can
+        happen only in a cyclic graph. In an acyclic tree the finished goods are
+        never returned, so their top-level BOM (e.g. bike -> frame) is preserved.
+        Cycle-safe (each node is visited at most once).
 
         Args:
             finished_good_ids: Product IDs of finished goods (e.g. complete bikes).
@@ -218,21 +222,23 @@ class Assemblies(Base):
     async def _expand_variants(self, assembly_ids: list[str]) -> set[str]:
         """Return all sibling variant IDs sharing a parent with the given assemblies.
 
-        Fetches the catalog once and groups by ``parent_id`` so every variant of a
-        detected assembly's family is included.
+        Fetches the catalog once and builds a single ``parent_id -> [product_id]``
+        index, so each detected assembly is resolved to its family by one dict
+        lookup (O(catalog + assemblies)) rather than a full re-scan per assembly.
         """
         catalog = await self._client.products.get_all_paginated()
-        by_id = {product.product_id: product for product in catalog}
+
+        by_id: dict[str, str | None] = {}
+        siblings_by_parent: dict[str, list[str]] = defaultdict(list)
+        for product in catalog:
+            parent_id = unwrap_unset(product.parent_id)
+            by_id[product.product_id] = parent_id
+            if parent_id is not None:
+                siblings_by_parent[parent_id].append(product.product_id)
 
         variant_ids: set[str] = set()
         for assembly_id in assembly_ids:
-            product = by_id.get(assembly_id)
-            parent_id = unwrap_unset(product.parent_id) if product else None
-            if parent_id is None:
-                continue
-            variant_ids.update(
-                candidate.product_id
-                for candidate in catalog
-                if is_variant_match(candidate, parent_id=parent_id)
-            )
+            parent_id = by_id.get(assembly_id)
+            if parent_id is not None:
+                variant_ids.update(siblings_by_parent[parent_id])
         return variant_ids

--- a/stocktrim_public_api_client/helpers/assemblies.py
+++ b/stocktrim_public_api_client/helpers/assemblies.py
@@ -1,0 +1,202 @@
+"""Assembly (BOM hierarchy) operations for purchased-vs-manufactured handling.
+
+Context: when StockTrim holds a multi-level BOM (e.g. complete bike -> frame ->
+frame parts), it explodes every level and generates purchase demand for the
+deepest components. For assemblies we buy whole (frames), we want explosion to
+stop at the assembly: keep its demand (it still rolls up from its parent BOM) and
+order it directly, but not generate demand for its sub-parts.
+
+StockTrim exposes no "is manufactured" flag; a product is treated as manufactured
+because it is itself a BOM parent. Removing an assembly's own sub-BOM (while
+leaving the parent -> assembly link intact) makes it behave as a purchased item.
+
+NOTE: this mechanism (sub-BOM strip) is the primary hypothesis pending live
+verification on a real frame SKU (Phase 0 of the plan). If verification shows
+``manufacturing_time`` is the actual lever instead, swap the body of
+``make_purchased`` — the detection and reconciliation logic is unaffected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from stocktrim_public_api_client.helpers.base import Base
+from stocktrim_public_api_client.helpers.products import is_variant_match
+from stocktrim_public_api_client.utils import unwrap_unset
+
+
+@dataclass
+class PurchasedAssemblyResult:
+    """Outcome of a :meth:`Assemblies.make_purchased` call for one assembly."""
+
+    product_id: str
+    removed_components: list[str] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        """True if any sub-BOM rows were removed."""
+        return bool(self.removed_components)
+
+
+@dataclass
+class ReconcileSummary:
+    """Aggregate outcome of a reconciliation run."""
+
+    detected: list[str]
+    results: list[PurchasedAssemblyResult]
+
+    @property
+    def changed(self) -> list[PurchasedAssemblyResult]:
+        """Results that actually removed sub-BOM rows."""
+        return [result for result in self.results if result.changed]
+
+    @property
+    def total_removed(self) -> int:
+        """Total number of sub-BOM rows removed across all assemblies."""
+        return sum(len(result.removed_components) for result in self.results)
+
+
+class Assemblies(Base):
+    """Treat intermediate assemblies as purchased items.
+
+    See module docstring for the rationale. The typical entry point is
+    :meth:`reconcile_purchased_assemblies`, which is idempotent and safe to run
+    on a schedule after each Katana import.
+    """
+
+    async def detect_finished_goods(self) -> list[str]:
+        """Find top-level finished goods: BOM parents that are never components.
+
+        Scans the whole BOM graph and returns product IDs that appear as a BOM
+        parent but never as a component of anything else (the roots of the tree,
+        e.g. complete bikes). Useful for seeding reconciliation without having to
+        enumerate finished goods by hand.
+
+        Returns:
+            Sorted, de-duplicated list of finished-good (root) product IDs.
+        """
+        all_boms = await self._client.bill_of_materials.get()
+        parents = {bom.product_id for bom in all_boms}
+        components = {bom.component_id for bom in all_boms}
+        return sorted(parents - components)
+
+    async def detect_purchased_assemblies(
+        self,
+        finished_good_ids: list[str],
+    ) -> list[str]:
+        """Find intermediate assemblies under the given finished goods.
+
+        For each finished good, inspects its direct components and returns those
+        components that are themselves BOM parents (i.e. have their own sub-BOM).
+        These are the "buy-it-whole" assemblies whose sub-BOM should be stripped.
+
+        Args:
+            finished_good_ids: Product IDs of finished goods (e.g. complete bikes).
+
+        Returns:
+            Sorted, de-duplicated list of intermediate-assembly product IDs.
+        """
+        boms = self._client.bill_of_materials
+        assemblies: set[str] = set()
+        for finished_good_id in finished_good_ids:
+            for component in await boms.get_for_product(finished_good_id):
+                component_id = component.component_id
+                if await boms.get_for_product(component_id):
+                    assemblies.add(component_id)
+        return sorted(assemblies)
+
+    async def make_purchased(self, product_id: str) -> PurchasedAssemblyResult:
+        """Make an assembly behave as purchased by removing its own sub-BOM.
+
+        Deletes every BOM row where ``product_id`` is the parent. The product's
+        usage as a component of higher-level BOMs is untouched, so its demand
+        still rolls up from those parents. Idempotent: a product with no sub-BOM
+        is a no-op.
+
+        Args:
+            product_id: The assembly (e.g. frame) to convert to purchased.
+
+        Returns:
+            PurchasedAssemblyResult listing the component IDs that were removed.
+        """
+        boms = self._client.bill_of_materials
+        result = PurchasedAssemblyResult(product_id=product_id)
+        for row in await boms.get_for_product(product_id):
+            await boms.delete(product_id=product_id, component_id=row.component_id)
+            result.removed_components.append(row.component_id)
+        return result
+
+    async def reconcile_purchased_assemblies(
+        self,
+        finished_good_ids: list[str] | None = None,
+        expand_variants: bool = True,
+        run_forecast: bool = True,
+    ) -> ReconcileSummary:
+        """Detect buy-it-whole assemblies, strip their sub-BOMs, and recalc.
+
+        End-to-end reconciliation:
+
+        1. Detect intermediate assemblies under ``finished_good_ids``.
+        2. Optionally expand each detected assembly to all sibling variants that
+           share its ``parent_id`` (the variant-relationship selector), so every
+           size/colour variant of a frame family is covered.
+        3. Strip each target's own sub-BOM (``make_purchased``).
+        4. Optionally trigger a forecast recalculation so the order plan reflects
+           the change — this supersedes the auto-recalc that StockTrim runs
+           immediately after a Katana import.
+
+        Idempotent: re-running after no new drift removes nothing and (if
+        ``run_forecast``) simply recomputes the same plan.
+
+        Args:
+            finished_good_ids: Product IDs of finished goods (e.g. complete bikes).
+                If ``None``, finished goods are auto-detected as BOM roots via
+                :meth:`detect_finished_goods`.
+            expand_variants: Expand detected assemblies to sibling variants via
+                ``parent_id``.
+            run_forecast: Trigger ``forecasting.run_calculations()`` at the end.
+
+        Returns:
+            ReconcileSummary describing what was detected and removed.
+        """
+        if finished_good_ids is None:
+            finished_good_ids = await self.detect_finished_goods()
+
+        detected = await self.detect_purchased_assemblies(finished_good_ids)
+        targets: set[str] = set(detected)
+
+        if expand_variants and detected:
+            targets |= await self._expand_variants(detected)
+
+        results = [
+            await self.make_purchased(product_id) for product_id in sorted(targets)
+        ]
+
+        summary = ReconcileSummary(detected=detected, results=results)
+
+        if run_forecast and summary.changed:
+            await self._client.forecasting.run_calculations()
+
+        return summary
+
+    async def _expand_variants(self, assembly_ids: list[str]) -> set[str]:
+        """Return all sibling variant IDs sharing a parent with the given assemblies.
+
+        Fetches the catalog once and groups by ``parent_id`` so every variant of a
+        detected assembly's family is included.
+        """
+        catalog = await self._client.products.get_all_paginated()
+        by_id = {product.product_id: product for product in catalog}
+
+        variant_ids: set[str] = set()
+        for assembly_id in assembly_ids:
+            product = by_id.get(assembly_id)
+            parent_id = unwrap_unset(product.parent_id) if product else None
+            if not parent_id:
+                continue
+            variant_ids.update(
+                candidate.product_id
+                for candidate in catalog
+                if is_variant_match(candidate, parent_id=parent_id)
+            )
+        return variant_ids

--- a/stocktrim_public_api_client/helpers/assemblies.py
+++ b/stocktrim_public_api_client/helpers/assemblies.py
@@ -18,11 +18,27 @@ verification on a real frame SKU (Phase 0 of the plan). If verification shows
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass, field
 
 from stocktrim_public_api_client.helpers.base import Base
 from stocktrim_public_api_client.helpers.products import is_variant_match
 from stocktrim_public_api_client.utils import unwrap_unset
+
+
+@dataclass
+class BomGraph:
+    """A snapshot of the whole BOM graph fetched in a single call.
+
+    Attributes:
+        children: Maps a product ID to the component IDs it directly contains.
+        parents: All product IDs that are a BOM parent (have a sub-BOM).
+        components: All product IDs that appear as a component of something.
+    """
+
+    children: dict[str, list[str]]
+    parents: set[str]
+    components: set[str]
 
 
 @dataclass
@@ -64,31 +80,45 @@ class Assemblies(Base):
     on a schedule after each Katana import.
     """
 
+    async def load_bom_graph(self) -> BomGraph:
+        """Fetch the entire BOM graph in one call.
+
+        Returns:
+            A :class:`BomGraph` snapshot (children map + parent/component sets).
+        """
+        children: dict[str, list[str]] = defaultdict(list)
+        parents: set[str] = set()
+        components: set[str] = set()
+        for bom in await self._client.bill_of_materials.get():
+            children[bom.product_id].append(bom.component_id)
+            parents.add(bom.product_id)
+            components.add(bom.component_id)
+        return BomGraph(children=dict(children), parents=parents, components=components)
+
     async def detect_finished_goods(self) -> list[str]:
         """Find top-level finished goods: BOM parents that are never components.
 
-        Scans the whole BOM graph and returns product IDs that appear as a BOM
-        parent but never as a component of anything else (the roots of the tree,
-        e.g. complete bikes). Useful for seeding reconciliation without having to
-        enumerate finished goods by hand.
+        Returns product IDs that appear as a BOM parent but never as a component
+        of anything else (the roots of the tree, e.g. complete bikes). Useful for
+        seeding reconciliation without enumerating finished goods by hand.
 
         Returns:
             Sorted, de-duplicated list of finished-good (root) product IDs.
         """
-        all_boms = await self._client.bill_of_materials.get()
-        parents = {bom.product_id for bom in all_boms}
-        components = {bom.component_id for bom in all_boms}
-        return sorted(parents - components)
+        graph = await self.load_bom_graph()
+        return sorted(graph.parents - graph.components)
 
     async def detect_purchased_assemblies(
         self,
         finished_good_ids: list[str],
     ) -> list[str]:
-        """Find intermediate assemblies under the given finished goods.
+        """Find intermediate assemblies in the subtree under the finished goods.
 
-        For each finished good, inspects its direct components and returns those
-        components that are themselves BOM parents (i.e. have their own sub-BOM).
-        These are the "buy-it-whole" assemblies whose sub-BOM should be stripped.
+        Walks the BOM tree below each finished good (to any depth) and returns
+        every descendant that is itself a BOM parent — i.e. has its own sub-BOM.
+        These are the "buy-it-whole" assemblies (e.g. frames) whose sub-BOM
+        should be stripped. The finished goods themselves are never returned, so
+        their top-level BOM (e.g. bike -> frame) is preserved. Cycle-safe.
 
         Args:
             finished_good_ids: Product IDs of finished goods (e.g. complete bikes).
@@ -96,13 +126,19 @@ class Assemblies(Base):
         Returns:
             Sorted, de-duplicated list of intermediate-assembly product IDs.
         """
-        boms = self._client.bill_of_materials
+        graph = await self.load_bom_graph()
         assemblies: set[str] = set()
-        for finished_good_id in finished_good_ids:
-            for component in await boms.get_for_product(finished_good_id):
-                component_id = component.component_id
-                if await boms.get_for_product(component_id):
-                    assemblies.add(component_id)
+        seen: set[str] = set()
+        stack = list(finished_good_ids)
+        while stack:
+            node = stack.pop()
+            if node in seen:
+                continue
+            seen.add(node)
+            for child in graph.children.get(node, []):
+                if child in graph.parents:
+                    assemblies.add(child)
+                stack.append(child)
         return sorted(assemblies)
 
     async def make_purchased(self, product_id: str) -> PurchasedAssemblyResult:
@@ -192,7 +228,7 @@ class Assemblies(Base):
         for assembly_id in assembly_ids:
             product = by_id.get(assembly_id)
             parent_id = unwrap_unset(product.parent_id) if product else None
-            if not parent_id:
+            if parent_id is None:
                 continue
             variant_ids.update(
                 candidate.product_id

--- a/stocktrim_public_api_client/helpers/bill_of_materials.py
+++ b/stocktrim_public_api_client/helpers/bill_of_materials.py
@@ -56,6 +56,12 @@ class BillOfMaterials(Base):
             product_id=product_id,
             component_id=component_id,
         )
+        # StockTrim returns 404 (not 200 with an empty array) when there are no
+        # matching BOMs — the same non-standard behavior as GET /api/Products.
+        # Treat it as "no results" so callers get a consistent empty list instead
+        # of a NotFoundError (verified against production, where GET /api/boms 404s).
+        if response.status_code == 404:
+            return []
         result = unwrap(response)
         return (
             cast(list[BillOfMaterialsResponseDto], result)

--- a/stocktrim_public_api_client/helpers/products.py
+++ b/stocktrim_public_api_client/helpers/products.py
@@ -17,7 +17,24 @@ from stocktrim_public_api_client.generated.models.products_response_dto import (
     ProductsResponseDto,
 )
 from stocktrim_public_api_client.helpers.base import Base
-from stocktrim_public_api_client.utils import unwrap
+from stocktrim_public_api_client.utils import unwrap, unwrap_unset
+
+
+def is_variant_match(
+    product: ProductsResponseDto,
+    parent_id: str | None = None,
+    variant_type: str | None = None,
+) -> bool:
+    """Return True if a product matches the given variant relationship filters.
+
+    A filter that is ``None`` is ignored. Both ``parent_id`` and ``variant_type``
+    are compared against the product's resolved (Unset-stripped) values.
+    """
+    if parent_id is not None and unwrap_unset(product.parent_id) != parent_id:
+        return False
+    return not (
+        variant_type is not None and unwrap_unset(product.variant_type) != variant_type
+    )
 
 
 class Products(Base):
@@ -159,6 +176,41 @@ class Products(Base):
         """
         product = await self.find_by_code(code)
         return product is not None
+
+    async def find_variants(
+        self,
+        parent_id: str | None = None,
+        variant_type: str | None = None,
+    ) -> list[ProductsResponseDto]:
+        """Find product variants sharing a parent and/or variant type.
+
+        Scans the full catalog and returns products matching the given variant
+        relationship. Useful for catching every size/colour variant of a product
+        family (e.g. all variants of a frame) rather than a single SKU.
+
+        Args:
+            parent_id: Optional parent product ID; variants reference their family
+                parent via ``parent_id``.
+            variant_type: Optional variant type discriminator (e.g. "SIZE").
+
+        Returns:
+            List of matching ProductsResponseDto objects.
+
+        Raises:
+            ValueError: If neither ``parent_id`` nor ``variant_type`` is provided
+                (an unfiltered call would return the whole catalog).
+
+        Example:
+            >>> variants = await client.products.find_variants(parent_id="FRAME-X")
+        """
+        if parent_id is None and variant_type is None:
+            raise ValueError("find_variants requires parent_id and/or variant_type")
+        catalog = await self.get_all_paginated()
+        return [
+            product
+            for product in catalog
+            if is_variant_match(product, parent_id, variant_type)
+        ]
 
     async def get_all_paginated(self) -> list[ProductsResponseDto]:
         """Get ALL products by paginating through all pages.

--- a/stocktrim_public_api_client/stocktrim_client.py
+++ b/stocktrim_public_api_client/stocktrim_client.py
@@ -24,6 +24,7 @@ from .generated.models.problem_details import ProblemDetails
 from .utils import unwrap_unset
 
 if TYPE_CHECKING:
+    from .helpers.assemblies import Assemblies
     from .helpers.bill_of_materials import BillOfMaterials
     from .helpers.customers import Customers
     from .helpers.forecasting import Forecasting
@@ -874,6 +875,15 @@ class StockTrimClient(AuthenticatedClient):
 
             self._bill_of_materials = BillOfMaterials(self)
         return self._bill_of_materials
+
+    @property
+    def assemblies(self) -> "Assemblies":
+        """Access the Assemblies helper for purchased-vs-manufactured BOM handling."""
+        if not hasattr(self, "_assemblies"):
+            from .helpers.assemblies import Assemblies
+
+            self._assemblies = Assemblies(self)
+        return self._assemblies
 
     async def _log_response_metrics(self, response: httpx.Response) -> None:
         """Log response metrics for observability."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -114,6 +114,12 @@ class TestHelpersIntegration:
         assert hasattr(stocktrim_client, "bill_of_materials")
         assert stocktrim_client.bill_of_materials is not None
 
+    def test_assemblies_helper_exists(self, stocktrim_client):
+        """Test assemblies helper is accessible and lazily cached."""
+        assert hasattr(stocktrim_client, "assemblies")
+        assert stocktrim_client.assemblies is not None
+        assert stocktrim_client.assemblies is stocktrim_client.assemblies
+
     def test_new_helpers_have_methods(self, stocktrim_client):
         """Test new helpers have expected core methods."""
         # OrderPlan

--- a/tests/test_helpers_assemblies.py
+++ b/tests/test_helpers_assemblies.py
@@ -101,6 +101,32 @@ async def test_detect_purchased_assemblies_finds_frame():
 
 
 @pytest.mark.asyncio
+async def test_detect_purchased_assemblies_recurses_to_any_depth():
+    # BIKE -> FORK -> CROWN -> TUBE: both FORK and CROWN are buy-it-whole
+    # assemblies (each has its own sub-BOM) several hops below the finished good.
+    graph = {
+        "BIKE": ["FORK"],
+        "FORK": ["CROWN"],
+        "CROWN": ["TUBE"],
+    }
+    client = _client_with(graph)
+    assemblies = Assemblies(client)
+
+    assert await assemblies.detect_purchased_assemblies(["BIKE"]) == ["CROWN", "FORK"]
+
+
+@pytest.mark.asyncio
+async def test_detect_purchased_assemblies_is_cycle_safe():
+    # Pathological cycle A <-> B must not hang the traversal.
+    graph = {"A": ["B"], "B": ["A", "C"]}
+    client = _client_with(graph)
+    assemblies = Assemblies(client)
+
+    # Seed explicitly (a pure cycle has no finished-good root).
+    assert await assemblies.detect_purchased_assemblies(["A"]) == ["A", "B"]
+
+
+@pytest.mark.asyncio
 async def test_make_purchased_strips_only_own_sub_bom():
     graph = _bike_graph()
     client = _client_with(graph)

--- a/tests/test_helpers_assemblies.py
+++ b/tests/test_helpers_assemblies.py
@@ -1,0 +1,223 @@
+"""Tests for the Assemblies helper and product variant expansion.
+
+These cover the "treat bike frames as purchased" reconciliation: detecting
+intermediate assemblies in a multi-level BOM (complete bike -> frame -> parts),
+stripping the frame's own sub-BOM while preserving the bike -> frame link,
+expanding to sibling variants, and triggering a recalc.
+
+Mocks are at the helper boundary (client.bill_of_materials / client.products /
+client.forecasting), matching the style used elsewhere in the suite.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from stocktrim_public_api_client.generated.models.bill_of_materials_response_dto import (
+    BillOfMaterialsResponseDto,
+)
+from stocktrim_public_api_client.generated.models.products_response_dto import (
+    ProductsResponseDto,
+)
+from stocktrim_public_api_client.helpers.assemblies import (
+    Assemblies,
+    PurchasedAssemblyResult,
+)
+from stocktrim_public_api_client.helpers.products import Products, is_variant_match
+
+
+def _bom(product_id: str, component_id: str) -> BillOfMaterialsResponseDto:
+    return BillOfMaterialsResponseDto(
+        product_id=product_id, component_id=component_id, quantity=1.0
+    )
+
+
+def _make_boms_mock(graph: dict[str, list[str]]) -> Mock:
+    """Build a mock bill_of_materials helper from a parent -> components graph.
+
+    ``get_for_product(pid)`` returns rows for ``graph[pid]``; ``get()`` (no args)
+    returns every edge; ``delete`` is an AsyncMock that mutates the graph so the
+    helper is observably idempotent on re-run.
+    """
+    boms = Mock()
+
+    async def get_for_product(product_id: str) -> list[BillOfMaterialsResponseDto]:
+        return [_bom(product_id, c) for c in graph.get(product_id, [])]
+
+    async def get(
+        product_id=None, component_id=None
+    ) -> list[BillOfMaterialsResponseDto]:
+        return [_bom(p, c) for p, comps in graph.items() for c in comps]
+
+    async def delete(product_id: str, component_id: str) -> None:
+        graph[product_id] = [c for c in graph.get(product_id, []) if c != component_id]
+
+    boms.get_for_product = AsyncMock(side_effect=get_for_product)
+    boms.get = AsyncMock(side_effect=get)
+    boms.delete = AsyncMock(side_effect=delete)
+    return boms
+
+
+def _client_with(graph: dict[str, list[str]], catalog=None) -> Mock:
+    client = Mock()
+    client.bill_of_materials = _make_boms_mock(graph)
+    client.forecasting = Mock()
+    client.forecasting.run_calculations = AsyncMock()
+    products = Mock()
+    products.get_all_paginated = AsyncMock(return_value=catalog or [])
+    client.products = products
+    return client
+
+
+# Topology used by most tests:
+#   BIKE -> FRAME, WHEEL          (complete bike)
+#   FRAME -> TUBE, LUG            (frame is itself an assembly -> buy-it-whole)
+def _bike_graph() -> dict[str, list[str]]:
+    return {
+        "BIKE": ["FRAME", "WHEEL"],
+        "FRAME": ["TUBE", "LUG"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_detect_finished_goods_returns_roots():
+    client = _client_with(_bike_graph())
+    assemblies = Assemblies(client)
+
+    # BIKE is a parent but never a component -> it is the only root.
+    assert await assemblies.detect_finished_goods() == ["BIKE"]
+
+
+@pytest.mark.asyncio
+async def test_detect_purchased_assemblies_finds_frame():
+    client = _client_with(_bike_graph())
+    assemblies = Assemblies(client)
+
+    # FRAME is a component of BIKE *and* has its own sub-BOM -> intermediate.
+    # WHEEL is a component with no sub-BOM -> not an assembly.
+    assert await assemblies.detect_purchased_assemblies(["BIKE"]) == ["FRAME"]
+
+
+@pytest.mark.asyncio
+async def test_make_purchased_strips_only_own_sub_bom():
+    graph = _bike_graph()
+    client = _client_with(graph)
+    assemblies = Assemblies(client)
+
+    result = await assemblies.make_purchased("FRAME")
+
+    assert isinstance(result, PurchasedAssemblyResult)
+    assert result.changed is True
+    assert sorted(result.removed_components) == ["LUG", "TUBE"]
+    # FRAME's sub-BOM is gone; the BIKE -> FRAME link is untouched.
+    assert graph["FRAME"] == []
+    assert graph["BIKE"] == ["FRAME", "WHEEL"]
+    client.bill_of_materials.delete.assert_any_call(
+        product_id="FRAME", component_id="TUBE"
+    )
+
+
+@pytest.mark.asyncio
+async def test_make_purchased_is_idempotent():
+    graph = _bike_graph()
+    client = _client_with(graph)
+    assemblies = Assemblies(client)
+
+    await assemblies.make_purchased("FRAME")
+    second = await assemblies.make_purchased("FRAME")
+
+    assert second.changed is False
+    assert second.removed_components == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_strips_frame_and_triggers_recalc():
+    graph = _bike_graph()
+    client = _client_with(graph)
+    assemblies = Assemblies(client)
+
+    summary = await assemblies.reconcile_purchased_assemblies(
+        expand_variants=False, run_forecast=True
+    )
+
+    assert summary.detected == ["FRAME"]
+    assert summary.total_removed == 2
+    assert graph["FRAME"] == []
+    # BIKE -> FRAME demand path preserved.
+    assert graph["BIKE"] == ["FRAME", "WHEEL"]
+    client.forecasting.run_calculations.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_recalc_when_nothing_changed():
+    # No intermediate assemblies: BIKE -> WHEEL only, WHEEL has no sub-BOM.
+    graph = {"BIKE": ["WHEEL"]}
+    client = _client_with(graph)
+    assemblies = Assemblies(client)
+
+    summary = await assemblies.reconcile_purchased_assemblies(run_forecast=True)
+
+    assert summary.changed == []
+    client.forecasting.run_calculations.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_expands_to_sibling_variants():
+    # FRAME and FRAME-L are size variants sharing parent FRAME-FAMILY. Only FRAME
+    # is referenced by a bike BOM, but expansion should also strip FRAME-L.
+    graph = {
+        "BIKE": ["FRAME"],
+        "FRAME": ["TUBE"],
+        "FRAME-L": ["TUBE"],
+    }
+    catalog = [
+        ProductsResponseDto(product_id="FRAME", parent_id="FRAME-FAMILY"),
+        ProductsResponseDto(product_id="FRAME-L", parent_id="FRAME-FAMILY"),
+        ProductsResponseDto(product_id="WHEEL", parent_id="WHEEL-FAMILY"),
+    ]
+    client = _client_with(graph, catalog=catalog)
+    assemblies = Assemblies(client)
+
+    summary = await assemblies.reconcile_purchased_assemblies(expand_variants=True)
+
+    assert summary.detected == ["FRAME"]
+    changed_ids = sorted(r.product_id for r in summary.changed)
+    assert changed_ids == ["FRAME", "FRAME-L"]
+    assert graph["FRAME"] == []
+    assert graph["FRAME-L"] == []
+
+
+@pytest.mark.asyncio
+async def test_find_variants_filters_catalog(monkeypatch):
+    catalog = [
+        ProductsResponseDto(product_id="FRAME", parent_id="FRAME-FAMILY"),
+        ProductsResponseDto(product_id="FRAME-L", parent_id="FRAME-FAMILY"),
+        ProductsResponseDto(product_id="WHEEL", parent_id="WHEEL-FAMILY"),
+    ]
+    products = Products(Mock())
+    monkeypatch.setattr(products, "get_all_paginated", AsyncMock(return_value=catalog))
+
+    variants = await products.find_variants(parent_id="FRAME-FAMILY")
+
+    assert sorted(p.product_id for p in variants) == ["FRAME", "FRAME-L"]
+
+
+@pytest.mark.asyncio
+async def test_find_variants_requires_a_filter():
+    products = Products(Mock())
+    with pytest.raises(ValueError, match="parent_id and/or variant_type"):
+        await products.find_variants()
+
+
+def test_is_variant_match_predicate():
+    product = ProductsResponseDto(
+        product_id="FRAME", parent_id="FRAME-FAMILY", variant_type="SIZE"
+    )
+    assert is_variant_match(product, parent_id="FRAME-FAMILY") is True
+    assert is_variant_match(product, parent_id="OTHER") is False
+    assert is_variant_match(product, variant_type="SIZE") is True
+    assert is_variant_match(product, variant_type="COLOR") is False
+    # No filters -> vacuously matches.
+    assert is_variant_match(product) is True

--- a/tests/test_helpers_bill_of_materials.py
+++ b/tests/test_helpers_bill_of_materials.py
@@ -1,0 +1,30 @@
+"""Tests for the BillOfMaterials helper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from stocktrim_public_api_client.helpers.bill_of_materials import BillOfMaterials
+
+
+@pytest.mark.asyncio
+async def test_get_returns_empty_list_on_404(monkeypatch):
+    """StockTrim answers 404 (not 200 + []) when there are no matching BOMs.
+
+    Verified against production, where GET /api/boms 404s. The helper must
+    normalize that to an empty list so callers (e.g. the assemblies
+    reconciliation) don't crash with NotFoundError on a BOM-less account.
+    """
+    import stocktrim_public_api_client.generated.api.bill_of_materials.get_api_boms as mod
+
+    response = Mock()
+    response.status_code = 404
+    monkeypatch.setattr(mod, "asyncio_detailed", AsyncMock(return_value=response))
+
+    boms = BillOfMaterials(Mock())
+
+    assert await boms.get() == []
+    assert await boms.get(product_id="WIDGET-001") == []
+    assert await boms.get_for_product("WIDGET-001") == []


### PR DESCRIPTION
## Summary

When Katana syncs multi-level BOMs into StockTrim (complete bike → frame → frame
parts), StockTrim explodes every level and generates purchase demand for the deepest
components. For assemblies we **buy whole** (frames), demand should stop at the
assembly: keep its demand (it still rolls up from the parent BOM) and order it
directly, but don't order its sub-parts.

StockTrim exposes no "is manufactured" flag — a product is treated as manufactured
because it is itself a BOM parent. So "make the frame purchased" means **stripping the
frame's own sub-BOM** while leaving the parent → frame link intact.

This PR adds:

- **`Assemblies` helper** (`helpers/assemblies.py`):
  - `load_bom_graph()` — fetch the whole BOM graph in one call
  - `detect_finished_goods()` — BOM roots (parents that are never components)
  - `detect_purchased_assemblies()` — descendants of finished goods that have their own
    sub-BOM, to **any depth**, cycle-safe
  - `make_purchased()` — strip an assembly's own sub-BOM (idempotent)
  - `reconcile_purchased_assemblies()` — detect → expand to sibling variants by
    `parent_id` → strip → trigger a forecast recalc (which **supersedes the auto-recalc**
    StockTrim runs immediately after a Katana import, so the post-import race is moot)
- **`products.find_variants()` / `is_variant_match()`** for variant expansion
- **`assemblies` property** on the client
- **`scripts/reconcile_purchased_assemblies.py`** — re-runnable, `--dry-run` supported,
  auto-detects finished goods; intended to run on a schedule covering Katana import
  frequency
- Unit tests covering detection (incl. multi-level + cycle), sub-BOM stripping
  (preserving the parent link), idempotency, variant expansion, and the recalc trigger

## ⚠️ Pending: Phase 0 live verification (do not deploy before this)

The sub-BOM-strip mechanism is the **primary hypothesis, not yet confirmed on a live
instance**. Before running against production, confirm on one real frame SKU that
stripping its sub-BOM + recalc drops the frame-parts demand while keeping the frame's.

Verification is currently blocked by two things found while probing the dev instance:
- No StockTrim credentials available in the build environment (can't run the client
  directly), and
- The StockTrim **Order Plan / forecast endpoint returns HTTP 500** on the instance
  (`search_products` and `forecasts_get_for_products` both 500), so the
  "observe demand before/after" step can't run yet.

If verification shows `manufacturing_time` is the real lever instead, `make_purchased()`
is the single method to swap — detection, variant expansion, scripting, and tests are
unaffected.

## Test plan

- [x] `uv run poe check` (lint + ty + full client & MCP test suites) passes
- [ ] **Phase 0:** against an instance with real frame data + a working order-plan
  endpoint: `uv run python scripts/reconcile_purchased_assemblies.py --dry-run` to
  confirm detected finished goods / frames, then on one frame confirm the order plan
  drops frame-parts demand after a strip + recalc while frame demand persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)