### PR TITLE
ci(release): migrate release automation off SEMANTIC_RELEASE_TOKEN PAT to GitHub App tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,18 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install UV
         uses: astral-sh/setup-uv@v4
@@ -82,7 +90,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9.15.2
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           root_options: -vv
 
       - name: Build client package
@@ -115,10 +123,18 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install UV
         uses: astral-sh/setup-uv@v4
@@ -198,8 +214,8 @@ jobs:
           # Commit the dependency update
           # Note: This chore(mcp) commit won't itself trigger a version bump (default_bump_level=0 for chore commits)
           # The subsequent semantic-release step will pick up this change and include it in the release
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "dougborg-release-please[bot]"
+          git config user.email "309159260+dougborg-release-please[bot]@users.noreply.github.com"
           git add stocktrim_mcp_server/pyproject.toml
           git diff --cached --quiet || git commit -m "chore(mcp): update client dependency to v${{ needs.release-client.outputs.version }}"
           git push
@@ -209,7 +225,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9.15.2
         with:
-          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           root_options: -vv
           directory: stocktrim_mcp_server
 


### PR DESCRIPTION
## What

Replaces the long-lived `secrets.SEMANTIC_RELEASE_TOKEN` PAT in `.github/workflows/release.yml` with short-lived GitHub App installation tokens minted from the `dougborg-release-please` App (App ID `4392719`, already installed on this repo with Contents/Issues/PRs read+write and Metadata read).

Every prior use of the PAT is replaced:

| Job | Step | Before | After |
|---|---|---|---|
| `release-client` | `actions/checkout` | `token: secrets.SEMANTIC_RELEASE_TOKEN` | `token: steps.app-token.outputs.token` |
| `release-client` | `python-semantic-release` | `github_token: secrets.SEMANTIC_RELEASE_TOKEN` | `github_token: steps.app-token.outputs.token` |
| `release-mcp` | `actions/checkout` | `token: secrets.SEMANTIC_RELEASE_TOKEN` | `token: steps.app-token.outputs.token` |
| `release-mcp` | `python-semantic-release` | `github_token: secrets.SEMANTIC_RELEASE_TOKEN` | `github_token: steps.app-token.outputs.token` |
| `release-mcp` | `git push` (MCP client-dependency bump commit) | credentials from PAT-authenticated checkout | credentials from App-token-authenticated checkout |

Each job mints its own installation token via `actions/create-github-app-token@v3` (pinned by tag, matching this repo's existing convention of tag-pinning first-party/verified actions) with `permission-contents: write` only — the minimum `python-semantic-release` needs to push commits/tags and create GitHub releases. No `issues`/`pull-requests` scopes were added since neither job touches issues or PRs.

The MCP dependency-bump commit's `git config user.*` was also switched from the generic `github-actions[bot]` identity to the App's own bot identity, `dougborg-release-please[bot]` (id `309159260`), so the commit is attributed to the actor that's actually authenticating and pushing it.

## Why

Retire a long-lived, broadly-scoped personal access token in favor of short-lived (1-hour), narrowly-scoped tokens minted per-job. Standard credential hygiene for release automation.

## Explicitly out of scope

- **No registry-auth changes.** PyPI publishing (`publish-client`/`publish-mcp`) uses OIDC/trusted publishing and is untouched. The `gh release upload` step in `build-mcpb` continues to use the default `secrets.GITHUB_TOKEN` — that's fine as-is and doesn't need an App token.
- **No branch-protection changes.** The "Protect Main" ruleset doesn't require PRs, so direct fast-forward pushes from an actor with write access (including this App, which has Contents: write) are already allowed. Nothing needed changing there.
- **No `--force` pushes anywhere in this workflow** — the MCP dependency-bump push is a plain `git push`, consistent with the ruleset's `non_fast_forward` and `required_linear_history` requirements.
- **Issue #176** (moving inline heredoc Python in `release.yml` to `scripts/`) is intentionally not addressed here to keep this PR focused on credential rotation.
- No secrets/variables were created, modified, or deleted. `SEMANTIC_RELEASE_TOKEN` is **left in place** as a rollback path.

## Rollout

1. Merge this PR.
2. Watch the next push-to-`main` release run closely — confirm both `release-client` and `release-mcp` jobs authenticate, push, and create releases successfully on the App token.
3. Only after a release has succeeded end-to-end on the new token should `SEMANTIC_RELEASE_TOKEN` be deleted from repo secrets (separate, manual follow-up — not part of this PR).

## Validation

- `actionlint` run before and after: identical shellcheck findings (pre-existing `SC2046`/`SC2086` quoting warnings in the two inline `run:` blocks, shifted by line number only from the new steps). No new findings introduced.
- Diff is scoped to the four PAT usages plus the two `git config` lines; no other workflow files reference `SEMANTIC_RELEASE_TOKEN` (verified by grep across `.github/workflows/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)