### PR TITLE
fix(release): stop release-mcp pushing from a stale main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,14 @@ jobs:
           # then is behind main, so track the branch tip instead.
           ref: main
 
+      # Belt-and-braces: guarantee we are on the post-release tip before
+      # reading versions or committing. Mirrors the pattern katana-openapi-client
+      # adopted for the same failure mode (dougborg/katana-openapi-client#901).
+      - name: Fast-forward to the post-release tip of main
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
+
       - name: Install UV
         uses: astral-sh/setup-uv@v4
         # Temporarily disable cache due to service issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          # release-client pushes a version-bump commit to main before this job
+          # starts. Checkout defaults to the workflow's triggering SHA, which by
+          # then is behind main, so track the branch tip instead.
+          ref: main
 
       - name: Install UV
         uses: astral-sh/setup-uv@v4
@@ -218,6 +222,10 @@ jobs:
           git config user.email "309159260+dougborg-release-please[bot]@users.noreply.github.com"
           git add stocktrim_mcp_server/pyproject.toml
           git diff --cached --quiet || git commit -m "chore(mcp): update client dependency to v${{ needs.release-client.outputs.version }}"
+
+          # Guard against anything landing on main between checkout and push.
+          # Rebase (not merge) to satisfy the branch ruleset's linear-history rule.
+          git pull --rebase origin main
           git push
 
       - name: Python Semantic Release (MCP)


### PR DESCRIPTION
## Problem

Release run [30169605854](https://github.com/dougborg/stocktrim-openapi-client/actions/runs/30169605854) released `client-v0.13.0` successfully, then `release-mcp` failed:

```
! [rejected]        main -> main (non-fast-forward)
hint: Updates were rejected because the tip of your current branch is behind
```

`release-mcp` correctly waits for `release-client` via `needs:`. The problem is that `actions/checkout` defaults to the **workflow's triggering SHA**, not the branch tip. By the time `release-mcp` runs, `release-client` has pushed `chore(release): client v0.13.0` to `main`, so the job is working one commit behind and its dependency-bump push is rejected.

This bug is not new and was not introduced by the App-token migration (#235). It was previously masked: the old `SEMANTIC_RELEASE_TOKEN` had stopped working (`fatal: could not read Username for 'https://github.com'`), so both jobs failed at auth before they could ever race. With auth fixed, the latent ordering bug surfaced.

## Fix

1. `ref: main` on the `release-mcp` checkout, so it starts from the post-`release-client` tip.
2. `git pull --rebase origin main` immediately before the push, guarding against anything landing in between. Rebase rather than merge, to satisfy the branch ruleset's `required_linear_history` rule.

## Verification

- `actionlint` reports no new findings; the two `SC2046`/`SC2086` warnings are pre-existing at line 78 and untouched here.
- `release-client` and PyPI publishing are unchanged.
- The MCP release for `client-v0.13.0` did not happen because of this failure; it should proceed on the next release run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ