### PR TITLE
fix(release): create mcp-v* GitHub release with .mcpb attached, not after

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,20 @@ jobs:
           git push
 
       - name: Python Semantic Release (MCP)
+        # vcs_release: false — the .mcpb bundle needs the post-bump version
+        # number (build_mcpb.py reads it from stocktrim_mcp_server/pyproject.toml)
+        # and must be attached as a release asset, but GitHub's immutable
+        # releases feature (repo-wide, deliberately enabled — see issue #952)
+        # rejects any asset upload once a release is published. PSR's own
+        # release creation is create-then-upload-as-separate-calls internally
+        # (see semantic_release.hvcs.github.GitHub.create_release), which
+        # publishes (draft: False) before the asset exists — that's exactly
+        # the 422 this fix addresses. So PSR only bumps the version, updates
+        # the changelog, and tags/pushes here; the build-mcpb job below
+        # creates the actual GitHub release afterward, with the bundle
+        # attached, via `gh release create` — which internally stages the
+        # release as a draft, uploads assets, then publishes, and is
+        # therefore immutable-release-safe.
         if: steps.check.outputs.should_release == 'true'
         id: release
         uses: python-semantic-release/python-semantic-release@v9.15.2
@@ -244,6 +258,7 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           root_options: -vv
           directory: stocktrim_mcp_server
+          vcs_release: false
 
       - name: Build MCP server package
         if: steps.release.outputs.released == 'true'
@@ -263,8 +278,10 @@ jobs:
   build-mcpb:
     name: Build MCPB bundle
     needs: release-mcp
-    # Only build the .mcpb when the MCP server actually released — the bundle
-    # is an asset on the mcp-v* GitHub release created by python-semantic-release.
+    # Only build the .mcpb when the MCP server actually released. release-mcp
+    # runs PSR with vcs_release: false, so the mcp-v* GitHub release does not
+    # exist yet at this point — this job creates it (with the bundle already
+    # attached) below.
     if: needs.release-mcp.outputs.released == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -312,15 +329,42 @@ jobs:
           name: mcpb
           path: ${{ steps.build.outputs.artifact }}
 
-      - name: Attach .mcpb to GitHub release
-        # python-semantic-release created the release matching the mcp-v* tag
-        # in the release-mcp job. Upload the .mcpb as an additional asset on
-        # that release.
+      - name: Extract release notes from CHANGELOG
+        # release-mcp ran PSR with vcs_release: false, so no GitHub release
+        # exists yet — this job creates it below. Reuse the changelog section
+        # PSR already wrote for this version as the release body, so the
+        # notes match what PSR would have generated itself.
+        id: notes
+        run: |
+          version="${{ needs.release-mcp.outputs.version }}"
+          notes_file="$(mktemp)"
+          awk -v ver="## v${version} " '
+            $0 ~ "^" ver { found=1; print; next }
+            found && /^## v/ { exit }
+            found { print }
+          ' stocktrim_mcp_server/CHANGELOG.md > "${notes_file}"
+
+          if [ ! -s "${notes_file}" ]; then
+            echo "::error::Could not find a '## v${version}' section in stocktrim_mcp_server/CHANGELOG.md"
+            exit 1
+          fi
+
+          echo "notes_file=${notes_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release with .mcpb attached
+        # Create the mcp-v* release now, with the .mcpb bundle attached in
+        # the same invocation. `gh release create <tag> <files...>` stages
+        # the release as a draft, uploads the given assets, then publishes —
+        # all internally — which is safe under immutable releases (unlike
+        # PSR's own release creation, which publishes before uploading; see
+        # the comment on the "Python Semantic Release (MCP)" step above).
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ needs.release-mcp.outputs.tag }}" \
-            "${{ steps.build.outputs.artifact }}" --clobber
+          gh release create "${{ needs.release-mcp.outputs.tag }}" \
+            "${{ steps.build.outputs.artifact }}" \
+            --title "${{ needs.release-mcp.outputs.tag }}" \
+            --notes-file "${{ steps.notes.outputs.notes_file }}"
 
   publish-client:
     name: Publish Client to PyPI


### PR DESCRIPTION
## The failure (observed)

Run [30169656024](https://github.com/dougborg/stocktrim-openapi-client/actions/runs/30169656024), job `Build MCPB bundle`, step `Attach .mcpb to GitHub release`:

```
HTTP 422: Cannot upload assets to an immutable release.
(https://uploads.github.com/repos/dougborg/stocktrim-openapi-client/releases/359829310/assets?...)
```

Release `mcp-v0.16.0` (id `359829310`) is `immutable: true` and has **zero assets**:

```
$ gh api repos/dougborg/stocktrim-openapi-client/releases/359829310 --jq '{immutable,assets:[.assets[].name]}'
{"immutable":true,"assets":[]}
```

## Root cause

`release-mcp` runs `python-semantic-release` (PSR), which creates *and publishes* the `mcp-v*` GitHub release as part of its own version step. `build-mcpb` runs afterward and tries `gh release upload "<tag>" <file> --clobber`. With immutable releases enabled repo-wide, a published release can never accept new assets — verified against PSR v9.15.2 source (`semantic_release.hvcs.github.GitHub.create_release`): it `POST`s the release with `"draft": False` and only *afterward* loops uploading any configured `assets` via separate calls. That internal create-then-upload split means even wiring the `.mcpb` through PSR's own `assets`/`dist_glob_patterns` config would hit the same 422 — the release is already immutable by the time the upload call runs.

## Why not disable immutable releases

Immutable releases are deliberate supply-chain hardening for this repo (issue #952), specifically because the `.mcpb` bundle is a distributable artifact — see the existing comment on the `Install mcpb CLI` step. This PR does not touch repo settings/rulesets/secrets; immutability stays on.

## What I verified vs. what I assumed

**Verified:**
- The 422 and the release's `immutable`/assetless state (above).
- PSR v9.15.2's `create_release()` source hardcodes `"draft": False` on creation, then uploads assets in a second loop of separate HTTP calls (`src/semantic_release/hvcs/github.py`). The `publish` CLI command (used by the alternate `publish-action` two-job pattern PSR's own docs show) only ever calls `upload_dists`, which requires an *existing* release found by tag — it never creates one. So neither PSR's `assets` config nor the documented `publish-action` pattern is immutable-release-safe.
- `build_mcpb.py` reads the version from `stocktrim_mcp_server/pyproject.toml` `[project.version]` directly (not from a git tag), so it only needs that file already bumped on the checked-out ref — it doesn't need PSR to have created a GitHub release first.
- GitHub's documented pattern for immutable releases is: create as a **draft**, attach assets to the draft (drafts are mutable regardless of the immutable-releases setting), then publish — assets already present at publish time, so no post-publish upload is needed. (GitHub Changelog: ["Immutable releases are now generally available"](https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/); community discussion [#178351](https://github.com/orgs/community/discussions/178351).)
- `gh release create <tag> <files...>` already implements exactly that draft → upload → publish sequence internally (cross-referenced via `cli/cli` issue history on draft-release fallback behavior, e.g. #5024/#6645, which describe the create-draft-first implementation). This is why `gh release create` with asset args is immutable-release-safe while PSR's own release creation and `gh release upload` (used against an already-published release) are not.
- `stocktrim_mcp_server/pyproject.toml`'s `[tool.semantic_release]` has no `[tool.semantic_release.publish]` override (root config's `upload_to_vcs_release = true` default applies), and no changelog override — so `stocktrim_mcp_server/CHANGELOG.md` gets the version section written regardless of whether PSR creates the GitHub release, which is what the new "Extract release notes" step reads.
- actionlint findings before/after (see below) — no new findings.

**Assumed (not independently re-verified against GitHub's source, only via community reporting):** the precise internal mechanics of `gh release create`'s draft-then-publish behavior. This is corroborated by multiple independent sources but I did not read the `cli/cli` Go source directly.

## Design chosen, and what I rejected

**Chosen:** `release-mcp`'s PSR step now runs with `vcs_release: false` — PSR still bumps the version, updates `CHANGELOG.md`, commits, tags, and pushes, but does **not** create a GitHub release. `build-mcpb` checks out that tag as before, builds the `.mcpb`, then creates the `mcp-v*` release itself in a single `gh release create "<tag>" "<file>" --title ... --notes-file ...` call, with release notes extracted from the `CHANGELOG.md` section PSR just wrote (so the release body matches what PSR would have generated).

**Rejected: attach the `.mcpb` via PSR's own `assets` config, built before PSR runs.** This was the task's nominally-preferred option, but PSR's `create_release()` internally still does publish-then-upload as two separate calls — it would 422 exactly like today, just at a different call site. Also impractical here: the `.mcpb` needs the *post-bump* version, which doesn't exist until PSR has already run.

**Rejected: keep `gh release upload` but retry/poll around immutability.** There's no grace period — the release is immutable the instant it's published (confirmed by the 422 firing immediately on the very next job). No amount of retrying fixes a fundamentally two-step create/upload sequence against an already-published release.

**Rejected: delete-and-recreate the release with assets after PSR publishes it.** GitHub protects tags used by immutable releases from deletion/move even if the release itself is later deleted, and this seemed likely to leave the repo in a worse, harder-to-reason-about state than just not letting PSR publish prematurely.

## Exact changes

- `.github/workflows/release.yml`:
  - `Python Semantic Release (MCP)` step: added `vcs_release: false`, with a comment explaining why.
  - `build-mcpb` job's stale comment (assumed PSR already created the release) corrected.
  - Replaced `Attach .mcpb to GitHub release` (`gh release upload --clobber`) with two steps: `Extract release notes from CHANGELOG` (awk-extracts the `## v<version>` section from `stocktrim_mcp_server/CHANGELOG.md`) and `Create GitHub release with .mcpb attached` (`gh release create <tag> <file> --title ... --notes-file ...`).
- Untouched: `release-client` job, PyPI publishing (`publish-client`/`publish-mcp`), the App-token minting added in #235, the `.mcpb` `actions/upload-artifact` step (still runs unconditionally, independent of release creation success).

## actionlint

Ran `actionlint .github/workflows/release.yml` on `main` and on this branch — identical output both times: pre-existing shellcheck SC2046/SC2086 warnings at lines 78 and 165 (both in code untouched by this PR, in the `release-client`/`release-mcp` "Check for … changes" steps). **No new findings introduced.**

## Residual risk on the next real release run

- Not dry-run-tested against a real immutable-release repo (would require an actual `feat(mcp):`/`fix(mcp):` commit landing on `main` and a full workflow run — out of scope for this PR per instructions not to merge). The individual mechanisms (PSR `vcs_release: false`, `gh release create` with assets) are each independently documented/verified, but their combination in this exact job graph is untested end-to-end.
- The changelog-extraction `awk` script assumes the `## v<version> (` heading format PSR's default template produces (confirmed present in `stocktrim_mcp_server/CHANGELOG.md` today); if PSR's changelog template config ever changes, this extraction step would need to change with it.
- If a future MCP release has an empty/malformed changelog section (e.g., changelog generation misconfigured), the new `Extract release notes` step fails loudly (`::error::` + `exit 1`) rather than silently creating a release with an empty body — intentional, but worth knowing this is now a hard gate that didn't exist before.

## Cannot retroactively fix mcp-v0.16.0

That release is immutable and already published assetless — no further asset upload is possible, by design. The `.mcpb` bundle is still recoverable: it's the `mcpb` workflow artifact on run [30169656024](https://github.com/dougborg/stocktrim-openapi-client/actions/runs/30169656024), not expired until **2026-10-23**.

## statuspro-openapi-client (reported, not fixed — separate repo)

`dougborg/statuspro-openapi-client`'s `.github/workflows/release-mcp.yml:118` has the same `gh release upload ... --clobber` pattern as this repo had. Its releases are currently mutable (`immutable: false`), so this is **latent, not broken** — it would hit the identical 422 the moment immutable releases are turned on there. Flagging for a future fix in that repo; out of scope here.

---

**Not merging this PR** — leaving for review per instructions.